### PR TITLE
Simplify and generalise interfaces

### DIFF
--- a/theories/BasicAST.v
+++ b/theories/BasicAST.v
@@ -2,14 +2,11 @@ From Stdlib Require Import Utf8 String.
 
 Set Primitive Projections.
 
-(** Reference in the global environment **)
+(** Reference in the global environment *)
 Definition gref := string.
 
-(** Reference in the extension environment (de Bruijn level) **)
-Definition eref := nat.
-
-(** Reference in an extension instance (de Bruijn index) **)
+(** Reference to an assumption (de Bruijn level) *)
 Definition aref := nat.
 
-(** Universe level **)
+(** Universe level *)
 Definition level := nat.

--- a/theories/GScope.v
+++ b/theories/GScope.v
@@ -24,30 +24,25 @@ Lemma inst_typing_gscope_ih Σ Ξ Γ ξ Ξ' :
   gscope_instance Σ ξ.
 Proof.
   intros h ih.
-  rewrite Forall_forall. intros σ hσ.
-  rewrite Forall_forall. intros u hu.
-  eapply In_nth_error in hσ as [M hM].
-  eapply In_nth_error in hu as [x hx].
-  destruct ih as [_ [ih e]]. red in ih. specialize (ih M).
-  destruct (ictx_get Ξ' M) as [[E ξ'] |] eqn:e'.
-  2:{
+  rewrite Forall_forall. intros o ho.
+  eapply In_nth_error in ho as [x hx].
+  destruct o as [u |]. 2: constructor.
+  constructor.
+  destruct ih as [heq [ih e]]. red in ih. specialize (ih x).
+  destruct (ictx_get Ξ' x) as [[] |] eqn:e'.
+  3:{
     unfold ictx_get in e'. destruct (_ <=? _) eqn: e1.
     - rewrite Nat.leb_le in e1. rewrite <- e in e1.
       rewrite <- nth_error_None in e1. congruence.
     - rewrite nth_error_None in e'.
       rewrite Nat.leb_gt in e1. lia.
-  }
-  specialize ih with (1 := eq_refl).
-  destruct ih as (hξ' & Ξ'' & Δ & R & hE & eM & ih).
-  rewrite hM in eM. cbn in eM.
-  destruct (nth_error Δ x) eqn: eΔ.
-  2:{
-    rewrite nth_error_None in eΔ. rewrite <- eM in eΔ.
-    rewrite <- nth_error_None in eΔ. congruence.
-  }
-  specialize ih with (1 := eΔ).
-  unfold iget in ih. rewrite hM, hx in ih.
-  assumption.
+    }
+    2:{
+      specialize (heq _ _ e'). cbn in heq. intuition congruence.
+    }
+    specialize ih with (1 := eq_refl).
+    unfold iget in ih. rewrite hx in ih.
+    apply ih.
 Qed.
 
 Lemma typing_gscope Σ Ξ Γ t A :
@@ -70,14 +65,10 @@ Proof.
   destruct h as (he & ht & e).
   split. 2: split.
   - assumption.
-  - intros M E ξ' eM.
-    specialize (ht _ _ _ eM). destruct ht as (? & Ξ'' & Δ & R & eE & ho & ht).
+  - intros x A hx. specialize (ht _ _ hx) as [].
     split. 1: assumption.
-    eexists _,_,_. split. 1 : eassumption.
-    split. 1: assumption.
-    intros x A hx. specialize ht with (1 := hx).
-    unfold iget in *. destruct (nth_error ξ _) as [σ |] eqn:e1. 2: constructor.
-    destruct (nth_error σ _) eqn:e2. 2: constructor.
+    unfold iget in *. 
+    destruct (nth_error ξ _) as [[] |] eqn:e1. 2,3: constructor.
     eapply typing_gscope. eassumption.
   - assumption.
 Qed.
@@ -111,19 +102,18 @@ Proof.
     + constructor. all: assumption.
 Qed.
 
-Lemma equation_typing_gscope Σ Ξ Δ r :
-  equation_typing Σ Ξ Δ r →
+Lemma equation_typing_gscope Σ Ξ r :
+  equation_typing Σ Ξ r →
   gscope_equation Σ r.
 Proof.
   intros (hctx & [i hty] & hl & hr).
   eapply typing_gscope in hl as gl, hr as gr, hty.
   eapply wf_gscope in hctx.
-  rewrite Forall_app in hctx.
   unfold gscope_equation. intuition eauto.
 Qed.
 
-Lemma equations_typing_gscope Σ Ξ Δ R :
-  Forall (equation_typing Σ Ξ Δ) R →
+Lemma equations_typing_gscope Σ Ξ R :
+  Forall (equation_typing Σ Ξ) R →
   Forall (gscope_equation Σ) R.
 Proof.
   eauto using Forall_impl, equation_typing_gscope.

--- a/theories/GScope.v
+++ b/theories/GScope.v
@@ -5,7 +5,7 @@
 
   The definition is in [Typing] for dependency reasons.
 
-**)
+*)
 
 From Stdlib Require Import Utf8 String List Arith Lia.
 From LocalComp.autosubst Require Import unscoped AST SubstNotations RAsimpl
@@ -21,7 +21,7 @@ Set Default Goal Selector "!".
 Lemma inst_typing_gscope_ih Σ Ξ Γ ξ Ξ' :
   inst_typing Σ Ξ Γ ξ Ξ' →
   inst_typing_ Σ Ξ (λ _ t _, gscope Σ t) Γ ξ Ξ' →
-  gscope_eargs Σ ξ.
+  gscope_instance Σ ξ.
 Proof.
   intros h ih.
   rewrite Forall_forall. intros σ hσ.
@@ -29,9 +29,9 @@ Proof.
   eapply In_nth_error in hσ as [M hM].
   eapply In_nth_error in hu as [x hx].
   destruct ih as [_ [ih e]]. red in ih. specialize (ih M).
-  destruct (ectx_get Ξ' M) as [[E ξ'] |] eqn:e'.
+  destruct (ictx_get Ξ' M) as [[E ξ'] |] eqn:e'.
   2:{
-    unfold ectx_get in e'. destruct (_ <=? _) eqn: e1.
+    unfold ictx_get in e'. destruct (_ <=? _) eqn: e1.
     - rewrite Nat.leb_le in e1. rewrite <- e in e1.
       rewrite <- nth_error_None in e1. congruence.
     - rewrite nth_error_None in e'.
@@ -46,7 +46,7 @@ Proof.
     rewrite <- nth_error_None in eΔ. congruence.
   }
   specialize ih with (1 := eΔ).
-  unfold eget in ih. rewrite hM, hx in ih.
+  unfold iget in ih. rewrite hM, hx in ih.
   assumption.
 Qed.
 
@@ -63,7 +63,7 @@ Qed.
 
 Lemma inst_typing_gscope Σ Ξ Γ ξ Ξ' :
   inst_typing Σ Ξ Γ ξ Ξ' →
-  gscope_eargs Σ ξ.
+  gscope_instance Σ ξ.
 Proof.
   intros h.
   eapply inst_typing_gscope_ih. 1: eassumption.
@@ -76,7 +76,7 @@ Proof.
     eexists _,_,_. split. 1 : eassumption.
     split. 1: assumption.
     intros x A hx. specialize ht with (1 := hx).
-    unfold eget in *. destruct (nth_error ξ _) as [σ |] eqn:e1. 2: constructor.
+    unfold iget in *. destruct (nth_error ξ _) as [σ |] eqn:e1. 2: constructor.
     destruct (nth_error σ _) eqn:e2. 2: constructor.
     eapply typing_gscope. eassumption.
   - assumption.

--- a/theories/Inlining.v
+++ b/theories/Inlining.v
@@ -494,7 +494,7 @@ Proof.
 Qed.
 
 Lemma inline_ictx_ext Σ Ξ κ κ' :
-  ewf Σ Ξ →
+  iwf Σ Ξ →
   eq_gscope Σ κ κ' →
   ⟦ Ξ ⟧e⟨ κ ⟩ = ⟦ Ξ ⟧e⟨ κ' ⟩.
 Proof.

--- a/theories/Inlining.v
+++ b/theories/Inlining.v
@@ -31,7 +31,6 @@ Section Inline.
 
   Context (Σ : gctx).
   Context (κ : ginst). (** A map from references to their translated def. *)
-  Context (Σᵗ : gctx). (** The translation of [Σ] *)
 
   Reserved Notation "⟦ t ⟧" (at level 0).
   Reserved Notation "⟦ k ⟧×" (at level 0).
@@ -157,7 +156,7 @@ Section Inline.
   Definition g_conv_unfold :=
     ∀ c Ξ' A t,
       Σ c = Some (Def Ξ' A t) →
-      Σᵗ ;; ⟦ Ξ' ⟧e | ∙ ⊢ κ c ≡ ⟦ t ⟧.
+      [] ;; ⟦ Ξ' ⟧e | ∙ ⊢ κ c ≡ ⟦ t ⟧.
 
   Context (h_conv_unfold : g_conv_unfold).
 
@@ -250,8 +249,8 @@ Section Inline.
   Qed.
 
   Lemma inst_equations_inline_ih Ξ Ξ' Γ ξ :
-    inst_equations_ (λ Γ u v, Σᵗ ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ u ⟧ ≡ ⟦ v ⟧) Γ ξ Ξ' →
-    inst_equations Σᵗ ⟦ Ξ ⟧e ⟦ Γ ⟧* ⟦ ξ ⟧× ⟦ Ξ' ⟧e.
+    inst_equations_ (λ Γ u v, [] ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ u ⟧ ≡ ⟦ v ⟧) Γ ξ Ξ' →
+    inst_equations [] ⟦ Ξ ⟧e ⟦ Γ ⟧* ⟦ ξ ⟧× ⟦ Ξ' ⟧e.
   Proof.
     intros ih.
     intros x rl hx.
@@ -280,7 +279,7 @@ Section Inline.
 
   Lemma conv_inline Ξ Γ u v :
     Σ ;; Ξ | Γ ⊢ u ≡ v →
-    Σᵗ ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ u ⟧ ≡ ⟦ v ⟧.
+    [] ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ u ⟧ ≡ ⟦ v ⟧.
   Proof.
     intros h.
     induction h using conversion_ind.
@@ -309,13 +308,13 @@ Section Inline.
   Definition g_type :=
     ∀ c Ξ' A t,
       Σ c = Some (Def Ξ' A t) →
-      Σᵗ ;; ⟦ Ξ' ⟧e | ∙ ⊢ κ c : ⟦ A ⟧.
+      [] ;; ⟦ Ξ' ⟧e | ∙ ⊢ κ c : ⟦ A ⟧.
 
   Context (h_type : g_type).
 
   Lemma inst_typing_inline Ξ Γ ξ Ξ' :
-    inst_typing_ Σ Ξ (λ Γ t A, Σᵗ ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ t ⟧ : ⟦ A ⟧) Γ ξ Ξ' →
-    inst_typing Σᵗ ⟦ Ξ ⟧e ⟦ Γ ⟧* ⟦ ξ ⟧× ⟦ Ξ' ⟧e.
+    inst_typing_ Σ Ξ (λ Γ t A, [] ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ t ⟧ : ⟦ A ⟧) Γ ξ Ξ' →
+    inst_typing [] ⟦ Ξ ⟧e ⟦ Γ ⟧* ⟦ ξ ⟧× ⟦ Ξ' ⟧e.
   Proof.
     intros (he & ih & e).
     split. 2: split.
@@ -335,7 +334,7 @@ Section Inline.
   Lemma typing_inline Ξ Γ t A :
     gwf Σ →
     Σ ;; Ξ | Γ ⊢ t : A →
-    Σᵗ ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ t ⟧ : ⟦ A ⟧.
+    [] ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ t ⟧ : ⟦ A ⟧.
   Proof.
     intros hΣ h.
     induction h using typing_ind.
@@ -528,7 +527,7 @@ Qed.
 
 Lemma gwf_conv_unfold Σ :
   gwf Σ →
-  g_conv_unfold Σ ⟦ Σ ⟧κ [].
+  g_conv_unfold Σ ⟦ Σ ⟧κ.
 Proof.
   intros h c Ξ' A t ec.
   induction h as [ | c' ??????? ih ].
@@ -551,7 +550,7 @@ Qed.
 
 Lemma gwf_type Σ :
   gwf Σ →
-  g_type Σ ⟦ Σ ⟧κ [].
+  g_type Σ ⟦ Σ ⟧κ.
 Proof.
   intros h.
   induction h as [ | c' ??????? ih ].

--- a/theories/Inversion.v
+++ b/theories/Inversion.v
@@ -103,14 +103,12 @@ Proof.
   intros h. invtac h.
 Qed.
 
-Lemma type_assm_inv Σ Ξ Γ M x T :
-  Σ ;; Ξ | Γ ⊢ assm M x : T →
-  ∃ E ξ Ξ' Δ R A,
-    ictx_get Ξ M = Some (E, ξ) ∧
-    Σ E = Some (Ext Ξ' Δ R) ∧
-    nth_error Δ x = Some A ∧
-    closed_instance ξ = true ∧
-    Σ ;; Ξ | Γ ⊢ delocal M (inst ξ (plus (S x) ⋅ A)) ≡ T.
+Lemma type_assm_inv Σ Ξ Γ x T :
+  Σ ;; Ξ | Γ ⊢ assm x : T →
+  ∃ A,
+    ictx_get Ξ x = Some (Assm A) ∧
+    closed A = true ∧
+    Σ ;; Ξ | Γ ⊢ A ≡ T.
 Proof.
   intros h. invtac h.
 Qed.
@@ -125,6 +123,6 @@ Ltac ttinv h h' :=
     | lam _ _ => eapply type_lam_inv in h as h'
     | app _ _ => eapply type_app_inv in h as h'
     | const _ _ => eapply type_const_inv in h as h'
-    | assm _ _ => eapply type_assm_inv in h as h'
+    | assm _ => eapply type_assm_inv in h as h'
     end
   end.

--- a/theories/Inversion.v
+++ b/theories/Inversion.v
@@ -1,4 +1,4 @@
-(** Inversion of typing **)
+(** Inversion of typing *)
 
 From Stdlib Require Import Utf8 String List Arith Lia.
 From LocalComp.autosubst Require Import unscoped AST SubstNotations RAsimpl
@@ -98,7 +98,7 @@ Lemma type_const_inv Σ Ξ Γ c ξ T :
     Σ c = Some (Def Ξ' A t) ∧
     inst_typing Σ Ξ Γ ξ Ξ' ∧
     closed A = true ∧
-    Σ ;; Ξ | Γ ⊢ einst ξ A ≡ T.
+    Σ ;; Ξ | Γ ⊢ inst ξ A ≡ T.
 Proof.
   intros h. invtac h.
 Qed.
@@ -106,11 +106,11 @@ Qed.
 Lemma type_assm_inv Σ Ξ Γ M x T :
   Σ ;; Ξ | Γ ⊢ assm M x : T →
   ∃ E ξ Ξ' Δ R A,
-    ectx_get Ξ M = Some (E, ξ) ∧
+    ictx_get Ξ M = Some (E, ξ) ∧
     Σ E = Some (Ext Ξ' Δ R) ∧
     nth_error Δ x = Some A ∧
-    closed_eargs ξ = true ∧
-    Σ ;; Ξ | Γ ⊢ delocal M (einst ξ (plus (S x) ⋅ A)) ≡ T.
+    closed_instance ξ = true ∧
+    Σ ;; Ξ | Γ ⊢ delocal M (inst ξ (plus (S x) ⋅ A)) ≡ T.
 Proof.
   intros h. invtac h.
 Qed.

--- a/theories/Pattern.v
+++ b/theories/Pattern.v
@@ -7,7 +7,7 @@
   symbol as a left-hand side to a rule.
   TODO: Improve
 
-**)
+*)
 
 From Stdlib Require Import Utf8 String List Arith Lia.
 From LocalComp.autosubst Require Import unscoped AST SubstNotations RAsimpl
@@ -35,7 +35,7 @@ Definition pat_to_term p :=
 
 (* TODO UPSTREAM *)
 Definition get_rule (Σ : gctx) Ξ M n : option crule :=
-  match ectx_get Ξ M with
+  match ictx_get Ξ M with
   | Some (E, ξ') =>
     match Σ E with
     | Some (Ext Ξ' Δ R) =>
@@ -46,7 +46,7 @@ Definition get_rule (Σ : gctx) Ξ M n : option crule :=
   end.
 
 Lemma get_get_rule (Σ : gctx) Ξ M n E ξ' Ξ' Δ R rl :
-  ectx_get Ξ M = Some (E, ξ') →
+  ictx_get Ξ M = Some (E, ξ') →
   Σ E = Some (Ext Ξ' Δ R) →
   nth_error R n = Some rl →
   get_rule Σ Ξ M n = Some rl.
@@ -74,11 +74,11 @@ Section Red.
   Reserved Notation "Γ ⊢ u ⇒ v"
     (at level 80, u, v at next level).
 
-  Context (Σ : gctx) (Ξ : ectx).
+  Context (Σ : gctx) (Ξ : ictx).
 
   Inductive pred (Γ : ctx) : term → term → Prop :=
 
-  (** Computation rules **)
+  (** Computation rules *)
 
   | pred_beta A t t' u u' :
       Γ ,, A ⊢ t ⇒ t' →
@@ -91,11 +91,11 @@ Section Red.
       closed t = true →
       ∙ ⊢ t ⇒ t' →
       Forall2 (Forall2 (pred Γ)) ξ ξ' →
-      Γ ⊢ const c ξ ⇒ einst ξ' t'
+      Γ ⊢ const c ξ ⇒ inst ξ' t'
 
   | pred_rule E Ξ' Δ R M ξ' n rule σ σ' :
       Σ E = Some (Ext Ξ' Δ R) →
-      ectx_get Ξ M = Some (E, ξ') →
+      ictx_get Ξ M = Some (E, ξ') →
       nth_error R n = Some rule →
       let δ := length Δ in
       let lhs := rlhs M ξ' δ rule in
@@ -106,7 +106,7 @@ Section Red.
       (∀ m, Γ ⊢ σ m ⇒ σ' m) →
       Γ ⊢ lhs <[ σ ] ⇒ rhs <[ σ' ]
 
-  (** Congruence rules **)
+  (** Congruence rules *)
 
   | pred_Pi A B A' B' :
       Γ ⊢ A ⇒ A' →
@@ -146,11 +146,11 @@ Section Red.
         P ∙ t t' →
         Forall2 (Forall2 (pred Γ)) ξ ξ' →
         Forall2 (Forall2 (P Γ)) ξ ξ' →
-        P Γ (const c ξ) (einst ξ' t')
+        P Γ (const c ξ) (inst ξ' t')
       ) →
       (∀ Γ E Ξ' Δ R M ξ' n rule σ σ',
         Σ E = Some (Ext Ξ' Δ R) →
-        ectx_get Ξ M = Some (E, ξ') →
+        ictx_get Ξ M = Some (E, ξ') →
         nth_error R n = Some rule →
         let δ := Datatypes.length Δ in
         let lhs := rlhs M ξ' δ rule in
@@ -249,11 +249,11 @@ Section Red.
       Σ c = Some (Def Ξ' A t) →
       ∙ ⊢ t ⇒ᵨ t' →
       Forall2 (Forall2 (pred_max Γ)) ξ ξ' →
-      Γ ⊢ const c ξ ⇒ᵨ einst ξ' t'
+      Γ ⊢ const c ξ ⇒ᵨ inst ξ' t'
 
   | pred_max_rule E Ξ' Δ R M ξ' n rule σ σ' :
       Σ E = Some (Ext Ξ' Δ R) →
-      ectx_get Ξ M = Some (E, ξ') →
+      ictx_get Ξ M = Some (E, ξ') →
       nth_error R n = Some rule →
       let δ := length Δ in
       let lhs := rlhs M ξ' δ rule in
@@ -261,7 +261,7 @@ Section Red.
       (∀ m, Γ ⊢ σ m ⇒ᵨ σ' m) →
       Γ ⊢ lhs <[ σ ] ⇒ᵨ rhs <[ σ' ]
 
-  (** Congruence rules **)
+  (** Congruence rules *)
 
   | pred_max_Pi A B A' B' :
       Γ ⊢ A ⇒ᵨ A' →
@@ -288,7 +288,7 @@ Section Red.
   Context (hpr : pattern_rules Σ Ξ).
 
   Lemma pattern_rules_lhs_no_lam M E ξ' Ξ' Δ R n rl σ A b :
-    ectx_get Ξ M = Some (E, ξ') →
+    ictx_get Ξ M = Some (E, ξ') →
     Σ E = Some (Ext Ξ' Δ R) →
     nth_error R n = Some rl →
     let δ := length Δ in

--- a/theories/Reduction.v
+++ b/theories/Reduction.v
@@ -9,7 +9,7 @@
   - Check that reduction as defined below is suitable for the usual proofs of
     confluence.
 
-**)
+*)
 
 From Stdlib Require Import Utf8 String List Arith Lia.
 From LocalComp.autosubst Require Import unscoped AST SubstNotations RAsimpl
@@ -32,11 +32,11 @@ Section Red.
   Reserved Notation "Γ ⊢ u ↦ v"
     (at level 80, u, v at next level).
 
-  Context (Σ : gctx) (Ξ : ectx).
+  Context (Σ : gctx) (Ξ : ictx).
 
   Inductive red1 (Γ : ctx) : term → term → Prop :=
 
-  (** Computation rules **)
+  (** Computation rules *)
 
   | red_beta A t u : Γ ⊢ app (lam A t) u ↦ t <[ u .. ]
 
@@ -44,11 +44,11 @@ Section Red.
       Σ c = Some (Def Ξ' A t) →
       inst_equations Σ Ξ Γ ξ Ξ' →
       closed t = true →
-      Γ ⊢ const c ξ ↦ einst ξ t
+      Γ ⊢ const c ξ ↦ inst ξ t
 
   | red_rule E Ξ' Δ R M ξ' n rule σ :
       Σ E = Some (Ext Ξ' Δ R) →
-      ectx_get Ξ M = Some (E, ξ') →
+      ictx_get Ξ M = Some (E, ξ') →
       nth_error R n = Some rule →
       let δ := length Δ in
       let lhs := rlhs M ξ' δ rule in
@@ -58,7 +58,7 @@ Section Red.
       scoped k rhs = true →
       Γ ⊢ lhs <[ σ ] ↦ rhs <[ σ ]
 
-  (** Congruence rules **)
+  (** Congruence rules *)
 
   | red_Pi_dom A B A' :
       Γ ⊢ A ↦ A' →
@@ -97,11 +97,11 @@ Section Red.
         Σ c = Some (Def Ξ' A t) →
         inst_equations Σ Ξ Γ ξ Ξ' →
         closed t = true →
-        P Γ (const c ξ) (einst ξ t)
+        P Γ (const c ξ) (inst ξ t)
       ) →
       (∀ Γ E Ξ' Δ R M ξ' n rule σ,
         Σ E = Some (Ext Ξ' Δ R) →
-        ectx_get Ξ M = Some (E, ξ') →
+        ictx_get Ξ M = Some (E, ξ') →
         nth_error R n = Some rule →
         let δ := Datatypes.length Δ in
         let lhs := rlhs M ξ' δ rule in
@@ -151,7 +151,7 @@ Notation "Σ ;; Ξ | Γ ⊢ u ↦ v" :=
   (red1 Σ Ξ Γ u v)
   (at level 80, u, v at next level).
 
-(** Reflexive transitive closure **)
+(** Reflexive transitive closure *)
 
 Definition red Σ Ξ Γ := clos_refl_trans _ (λ u v, Σ ;; Ξ | Γ ⊢ u ↦ v).
 
@@ -159,7 +159,7 @@ Notation "Σ ;; Ξ | Γ ⊢ u ↦* v" :=
   (red Σ Ξ Γ u v)
   (at level 80, u, v at next level).
 
-(** Equivalence **)
+(** Equivalence *)
 
 Definition equiv Σ Ξ Γ := clos_refl_sym_trans _ (λ u v, Σ ;; Ξ | Γ ⊢ u ↦ v).
 
@@ -203,7 +203,7 @@ Proof.
   eapply rst_step_ind. all: eauto.
 Qed.
 
-(** Notion of confluence **)
+(** Notion of confluence *)
 
 Definition red_confluent Σ Ξ :=
   ∀ Γ t u v,
@@ -213,7 +213,7 @@ Definition red_confluent Σ Ξ :=
       Σ ;; Ξ | Γ ⊢ u ↦* w ∧
       Σ ;; Ξ | Γ ⊢ v ↦* w.
 
-(** Joinability **)
+(** Joinability *)
 
 Definition joinable Σ Ξ Γ u v :=
   ∃ w,
@@ -224,7 +224,7 @@ Notation "Σ ;; Ξ | Γ ⊢ u ⋈ v" :=
   (joinable Σ Ξ Γ u v)
   (at level 80, u, v at next level).
 
-(** Assuming confluence, equivalence is the same as joinability **)
+(** Assuming confluence, equivalence is the same as joinability *)
 
 Lemma equiv_join Σ Ξ Γ u v :
   red_confluent Σ Ξ →
@@ -246,7 +246,7 @@ Proof.
     + eapply rt_trans. all: eassumption.
 Qed.
 
-(** Conversion is included in the congruence closure of reduction **)
+(** Conversion is included in the congruence closure of reduction *)
 
 Lemma equiv_Pi Σ Ξ Γ A A' B B' :
   Σ ;; Ξ | Γ ⊢ A ↮ A' →
@@ -318,7 +318,7 @@ Proof.
   - eapply equiv_const. assumption.
 Qed.
 
-(** One-step reduction embeds in conversion **)
+(** One-step reduction embeds in conversion *)
 
 #[export] Instance Reflexive_conversion Σ Ξ Γ :
   Reflexive (conversion Σ Ξ Γ).
@@ -335,10 +335,10 @@ Proof.
   rewrite Forall_forall. intros t ht.
   apply In_nth_error in hσ as [n hn].
   apply In_nth_error in ht as [m hm].
-  unfold inst_eget in h.
+  unfold inst_iget in h.
   specialize (h n).
-  destruct ectx_get as [[E ξ']|] eqn: eg.
-  2:{ unfold ectx_get in eg. destruct (_ <=? _) eqn: en.
+  destruct ictx_get as [[E ξ']|] eqn: eg.
+  2:{ unfold ictx_get in eg. destruct (_ <=? _) eqn: en.
     - rewrite Nat.leb_le in en.
       rewrite <- e in en.
       rewrite <- nth_error_None in en.
@@ -353,13 +353,13 @@ Proof.
   destruct (nth_error Δ m) eqn: em.
   2:{ rewrite nth_error_None in em. apply nth_error_Some_alt in hm. lia. }
   specialize h with (1 := em).
-  unfold eget in h. rewrite hn, hm in h.
+  unfold iget in h. rewrite hn, hm in h.
   eexists. eassumption.
 Qed.
 
 (* Definition factor_rules (Σ : gctx) Ξ :=
   ∀ M E ξ' Ξ' Δ R n rule σ Γ A,
-    ectx_get Ξ M = Some (E, ξ') →
+    ictx_get Ξ M = Some (E, ξ') →
     Σ E = Some (Ext Ξ' Δ R) →
     nth_error R n = Some rule →
     let δ := length Δ in
@@ -407,7 +407,7 @@ Qed.
 
 Reserved Notation "Σ ;; Ξ | Γ ↦* Δ" (at level 80).
 
-Inductive red_ctx (Σ : gctx) (Ξ : ectx) : ctx → ctx → Prop :=
+Inductive red_ctx (Σ : gctx) (Ξ : ictx) : ctx → ctx → Prop :=
 | red_nil : Σ ;; Ξ | ∙ ↦* ∙
 | red_cons Γ Δ A B :
     Σ ;; Ξ | Γ ↦* Δ →
@@ -452,11 +452,11 @@ Abort.
   To prove it, we need more constraints about computation rules.
   If they can have a Π on the left-hand side we lose.
 
-**)
+*)
 
 Definition no_pi_lhs (Σ : gctx) Ξ :=
   ∀ M E ξ' Ξ' Δ R n rule σ A B,
-    ectx_get Ξ M = Some (E, ξ') →
+    ictx_get Ξ M = Some (E, ξ') →
     Σ E = Some (Ext Ξ' Δ R) →
     nth_error R n = Some rule →
     let δ := length Δ in

--- a/theories/Typing.v
+++ b/theories/Typing.v
@@ -169,6 +169,7 @@ Section Inst.
   Definition inst_iget_ (Γ : ctx) (ξ : instance) (Ξ' : ictx) :=
     ∀ n A,
       ictx_get Ξ' n = Some (Assm A) →
+      closed A = true ∧
       Γ ⊢ iget ξ n : inst ξ A.
 
   Definition inst_typing_ (Γ : ctx) (ξ : instance) (Ξ' : ictx) :=
@@ -218,6 +219,7 @@ Inductive typing (Γ : ctx) : term → term → Prop :=
 | type_assm :
     ∀ x A,
       ictx_get Ξ x = Some (Assm A) →
+      closed A = true →
       Γ ⊢ assm x : A
 
 | type_conv :
@@ -343,5 +345,5 @@ Proof.
 Qed.
 
 Notation inst_equations Σ Ξ := (inst_equations_ (conversion Σ Ξ)).
-Notation inst_iget Σ Ξ := (inst_iget_ Σ (typing Σ Ξ)).
+Notation inst_iget Σ Ξ := (inst_iget_ (typing Σ Ξ)).
 Notation inst_typing Σ Ξ := (inst_typing_ Σ Ξ (typing Σ Ξ)).

--- a/theories/Typing.v
+++ b/theories/Typing.v
@@ -80,8 +80,9 @@ Section Equations.
       let Θ := ctx_inst ξ rl.(cr_env) in
       let lhs := inst (liftn m ξ) rl.(cr_pat) in
       let rhs := inst (liftn m ξ) rl.(cr_rep) in
-      scoped m lhs = true ∧
-      scoped m rhs = true ∧
+      nth_error ξ x = None ∧
+      scoped m rl.(cr_pat) = true ∧
+      scoped m rl.(cr_rep) = true ∧
       Γ ,,, Θ ⊢ lhs ≡ rhs.
 
 End Equations.

--- a/theories/Util.v
+++ b/theories/Util.v
@@ -384,9 +384,89 @@ Definition onSomeT [A] (P : A → Type) (o : option A) : Type :=
   | None => unit
   end.
 
+Lemma onSomeT_impl A P Q o :
+  (∀ a, P a → Q a) →
+  @onSomeT A P o →
+  onSomeT Q o.
+Proof.
+  intros hPQ h.
+  destruct o. all: cbn in *. all: auto.
+Qed.
+
+Lemma onSomeT_prod A P Q o :
+  @onSomeT A P o →
+  onSomeT Q o →
+  onSomeT (λ x, P x * Q x)%type o.
+Proof.
+  destruct o. all: cbn. all: auto.
+Qed.
+
+Lemma onSomeb_onSome A P o :
+  @onSomeb A P o = true ↔ onSome (λ x, P x = true) o.
+Proof.
+  split. all: destruct o. all: cbn. all: auto.
+Qed.
+
+Lemma onSome_onSomeT A P o :
+  @onSome A P o →
+  onSomeT P o.
+Proof.
+  destruct o. all: cbn.
+  - auto.
+  - intros. constructor.
+Qed.
+
 Inductive option_rel [A] (R : A → A → Prop) : option A → option A → Prop :=
 | option_none : option_rel R None None
 | option_some x y : R x y → option_rel R (Some x) (Some y).
+
+Lemma option_rel_impl [A] (R R' : A → A → Prop) x y :
+  inclusion _ R R' →
+  option_rel R x y →
+  option_rel R' x y.
+Proof.
+  intros hinc h.
+  destruct h.
+  - constructor.
+  - constructor. eauto.
+Qed.
+
+Lemma option_map_option_map [A B C] (f : A → B) (g : B → C) o :
+  option_map g (option_map f o) = option_map (λ x, g (f x)) o.
+Proof.
+  destruct o. all: reflexivity.
+Qed.
+
+Lemma option_map_ext [A B] (f g : A → B) o :
+  (∀ a, f a = g a) →
+  option_map f o = option_map g o.
+Proof.
+  intros e.
+  destruct o. 2: reflexivity.
+  cbn. f_equal. auto.
+Qed.
+
+Lemma option_map_ext_onSomeT [A B] (f g : A → B) o :
+  onSomeT (λ x, f x = g x) o →
+  option_map f o = option_map g o.
+Proof.
+  destruct o. all: cbn. all: congruence.
+Qed.
+
+Lemma option_map_id [A] o :
+  @option_map A A id o = o.
+Proof.
+  destruct o. all: reflexivity.
+Qed.
+
+Lemma option_map_id_onSomeT [A] f (o : option A) :
+  onSomeT (λ x, f x = x) o →
+  option_map f o = o.
+Proof.
+  intro h.
+  rewrite <- option_map_id.
+  apply option_map_ext_onSomeT. assumption.
+Qed.
 
 (** [fold_left] util *)
 

--- a/theories/Util.v
+++ b/theories/Util.v
@@ -50,7 +50,7 @@ Ltac wlog_iff_using tac :=
 Ltac wlog_iff :=
   wlog_iff_using firstorder.
 
-(** Relations **)
+(** Relations *)
 
 Lemma rt_step_ind A B R R' f x y :
   (∀ x y, R x y → clos_refl_trans B R' (f x) (f y)) →
@@ -93,7 +93,7 @@ Proof.
   auto.
 Qed.
 
-(** [All] predicate **)
+(** [All] predicate *)
 
 Inductive All {A} (P : A → Type) : list A → Type :=
 | All_nil : All P []
@@ -241,7 +241,7 @@ Proof.
   apply Forall2_diag. rewrite Forall_forall. auto.
 Qed.
 
-(** [OnOne2] predicate **)
+(** [OnOne2] predicate *)
 
 Inductive OnOne2 {A} (R : A → A → Prop) : list A → list A → Prop :=
 | OnOne2_hd a a' l : R a a' → OnOne2 R (a :: l) (a' :: l)
@@ -317,7 +317,7 @@ Proof.
   - constructor. inversion hf. intuition auto.
 Qed.
 
-(** Some mini [congruence] **)
+(** Some mini [congruence] *)
 
 Ltac eqtwice :=
   match goal with
@@ -325,7 +325,7 @@ Ltac eqtwice :=
     rewrite e2 in e1 ; inversion e1 ; clear e1
   end.
 
-(** On [nth_error] **)
+(** On [nth_error] *)
 
 Lemma nth_error_Some_alt A (l : list A) n x :
   nth_error l n = Some x →
@@ -335,7 +335,7 @@ Proof.
   rewrite <- nth_error_Some. congruence.
 Qed.
 
-(** [option] util **)
+(** [option] util *)
 
 Definition onSome [A] (P : A → Prop) (o : option A) : Prop :=
   match o with
@@ -360,7 +360,29 @@ Proof.
   - cbn. reflexivity.
 Qed.
 
-(** [fold_left] util **)
+Definition onSomeb [A] (P : A → bool) (o : option A) : bool :=
+  match o with
+  | Some a => P a
+  | None => true
+  end.
+
+Inductive OnSome [A] (P : A → Prop) : option A → Prop :=
+| OnSome_None : OnSome P None
+| OnSome_Some a : P a → OnSome P (Some a).
+
+Lemma OnSome_onSome A P o :
+  @OnSome A P o ↔ onSome P o.
+Proof.
+  split.
+  - destruct 1. all: cbn. all: auto.
+  - destruct o. all: cbn. all: intros ; constructor ; auto.
+Qed.
+
+Inductive option_rel [A] (R : A → A → Prop) : option A → option A → Prop :=
+| option_none : option_rel R None None
+| option_some x y : R x y → option_rel R (Some x) (Some y).
+
+(** [fold_left] util *)
 
 Lemma fold_left_map A B C (f : A → B → A) l a g :
   fold_left f (map g l) a = fold_left (λ a (c : C), f a (g c)) l a.

--- a/theories/Util.v
+++ b/theories/Util.v
@@ -486,6 +486,14 @@ Proof.
   intros h. destruct h. all: constructor ; auto.
 Qed.
 
+#[export] Instance Reflexive_option_rel A (R : relation A) :
+  Reflexive R →
+  Reflexive (option_rel R).
+Proof.
+  intros hrefl. intros o.
+  apply option_rel_diag. destruct o. all: constructor ; eauto.
+Qed.
+
 Lemma option_map_option_map [A B C] (f : A → B) (g : B → C) o :
   option_map g (option_map f o) = option_map (λ x, g (f x)) o.
 Proof.
@@ -521,6 +529,35 @@ Proof.
   intro h.
   rewrite <- option_map_id.
   apply option_map_ext_onSomeT. assumption.
+Qed.
+
+Inductive some_rel [A B] (R : A → B → Prop) : option A → option B → Prop :=
+| some_rel_some a b : R a b → some_rel R (Some a) (Some b).
+
+Lemma option_rel_rst_some_rel A (R : relation A) a b :
+  option_rel R a b →
+  clos_refl_sym_trans _ (some_rel R) a b.
+Proof.
+  intros h. destruct h.
+  - apply rst_refl.
+  - apply rst_step. constructor. assumption.
+Qed.
+
+Lemma some_rel_rst_comm A R x y :
+  some_rel (clos_refl_sym_trans A R) x y →
+  clos_refl_sym_trans _ (some_rel R) x y.
+Proof.
+  intros h. destruct h.
+  eapply rst_step_ind. 2: eassumption.
+  intros. apply rst_step. constructor. assumption.
+Qed.
+
+Lemma some_rel_option_rel A B (R : A → B → Prop) a b :
+  some_rel R a b →
+  option_rel R a b.
+Proof.
+  intro h. destruct h.
+  constructor. assumption.
 Qed.
 
 (** [fold_left] util *)

--- a/theories/Util.v
+++ b/theories/Util.v
@@ -416,12 +416,12 @@ Proof.
   - intros. constructor.
 Qed.
 
-Inductive option_rel [A] (R : A → A → Prop) : option A → option A → Prop :=
+Inductive option_rel [A B] (R : A → B → Prop) : option A → option B → Prop :=
 | option_none : option_rel R None None
 | option_some x y : R x y → option_rel R (Some x) (Some y).
 
-Lemma option_rel_impl [A] (R R' : A → A → Prop) x y :
-  inclusion _ R R' →
+Lemma option_rel_impl [A B] (R R' : A → B → Prop) x y :
+  (∀ x y, R x y → R' x y) →
   option_rel R x y →
   option_rel R' x y.
 Proof.
@@ -429,6 +429,38 @@ Proof.
   destruct h.
   - constructor.
   - constructor. eauto.
+Qed.
+
+Lemma option_rel_map_l A B C (f : A → B) (R : B → C → Prop) o o' :
+  option_rel R (option_map f o) o' ↔ option_rel (λ x y, R (f x) y) o o'.
+Proof.
+  split.
+  - intro h. remember (option_map f o) as o'' eqn: e.
+    induction h in o, e |- *.
+    + destruct o. 1: discriminate.
+      constructor.
+    + destruct o. 2: discriminate.
+      cbn in e. inversion e. subst.
+      constructor. assumption.
+  - intro h. induction h. 1: constructor.
+    cbn. constructor. assumption.
+Qed.
+
+Lemma option_rel_flip A B R a b :
+  @option_rel A B R a b →
+  option_rel (λ b a, R a b) b a.
+Proof.
+  intro h. induction h. all: constructor ; auto.
+Qed.
+
+Lemma option_rel_map_r A B C (f : A → B) R (o : option C) o' :
+  option_rel R o (option_map f o') ↔ option_rel (λ x y, R x (f y)) o o'.
+Proof.
+  split.
+  - intro h. apply option_rel_flip in h. rewrite option_rel_map_l in h.
+    apply option_rel_flip. assumption.
+  - intro h. apply option_rel_flip in h.
+    apply option_rel_flip. rewrite option_rel_map_l. assumption.
 Qed.
 
 Lemma option_map_option_map [A B C] (f : A → B) (g : B → C) o :

--- a/theories/Util.v
+++ b/theories/Util.v
@@ -416,6 +416,22 @@ Proof.
   - intros. constructor.
 Qed.
 
+Lemma onSomeT_onSome A (P : _ → Prop) o :
+  @onSomeT A P o →
+  onSome P o.
+Proof.
+  destruct o. all: cbn.
+  - auto.
+  - intros. constructor.
+Qed.
+
+Lemma onSomeT_map [A B] (f : A → B) P o :
+  onSomeT (λ x, P (f x)) o → 
+  onSomeT P (option_map f o).
+Proof.
+  intros h. destruct o. all: cbn in *. all: auto.
+Qed.
+
 Inductive option_rel [A B] (R : A → B → Prop) : option A → option B → Prop :=
 | option_none : option_rel R None None
 | option_some x y : R x y → option_rel R (Some x) (Some y).
@@ -461,6 +477,13 @@ Proof.
     apply option_rel_flip. assumption.
   - intro h. apply option_rel_flip in h.
     apply option_rel_flip. rewrite option_rel_map_l. assumption.
+Qed.
+
+Lemma option_rel_diag [A] (R : A → A → Prop) o :
+  OnSome (λ x, R x x) o →
+  option_rel R o o.
+Proof.
+  intros h. destruct h. all: constructor ; auto.
 Qed.
 
 Lemma option_map_option_map [A B C] (f : A → B) (g : B → C) o :

--- a/theories/Util.v
+++ b/theories/Util.v
@@ -378,6 +378,12 @@ Proof.
   - destruct o. all: cbn. all: intros ; constructor ; auto.
 Qed.
 
+Definition onSomeT [A] (P : A → Type) (o : option A) : Type :=
+  match o with
+  | Some a => P a
+  | None => unit
+  end.
+
 Inductive option_rel [A] (R : A → A → Prop) : option A → option A → Prop :=
 | option_none : option_rel R None None
 | option_some x y : R x y → option_rel R (Some x) (Some y).

--- a/theories/autosubst/AST.sig
+++ b/theories/autosubst/AST.sig
@@ -1,10 +1,10 @@
 list : Functor
+option : Functor
 
 -- Global references
 gref : Type
 
--- Extension references
-eref : Type
+-- Assumption references
 aref : Type
 
 -- Universe levels
@@ -20,5 +20,5 @@ Pi : term -> (bind term in term) -> term
 lam : term -> (bind term in term) -> term
 app : term -> term -> term
 
-const : gref -> "list" ("list" (term)) -> term
-assm : eref -> aref -> term
+const : gref -> "list" ("option" (term)) -> term
+assm : aref -> term

--- a/theories/autosubst/AST_rasimpl.v
+++ b/theories/autosubst/AST_rasimpl.v
@@ -1,4 +1,4 @@
-(** GAST support for rasimpl **)
+(** GAST support for rasimpl *)
 
 From Stdlib Require Import Utf8 List.
 From LocalComp.autosubst
@@ -38,7 +38,7 @@ with unquote_term q :=
   | qsubst s t => subst_term (unquote_subst s) (unquote_term t)
   end.
 
-(** Evaluation **)
+(** Evaluation *)
 
 Inductive eval_subst_comp_view : quoted_subst → quoted_subst → Type :=
 | es_id_l s : eval_subst_comp_view qsubst_id s
@@ -216,7 +216,7 @@ with eval_term (t : quoted_term) : quoted_term :=
   | _ => t
   end.
 
-(** Correctness **)
+(** Correctness *)
 
 Lemma apply_subst_sound :
   ∀ s n,
@@ -397,7 +397,7 @@ Proof.
   }
 Qed.
 
-(** Quoting **)
+(** Quoting *)
 
 Ltac quote_subst s :=
   lazymatch s with
@@ -445,7 +445,7 @@ with quote_term t :=
   | _ => constr:(qatom t)
   end.
 
-(** Unfoldings **)
+(** Unfoldings *)
 
 #[export] Hint Unfold
   VarInstance_term Ren_term Up_term_term Up_term up_term Subst_term
@@ -513,7 +513,7 @@ Proof.
   apply autosubst_simpl_term, _.
 Qed.
 
-(** Triggers **)
+(** Triggers *)
 
 #[export] Hint Rewrite -> autosubst_simpl_term_ren : asimpl.
 #[export] Hint Rewrite -> autosubst_simpl_term_subst : asimpl.

--- a/theories/autosubst/RAsimpl.v
+++ b/theories/autosubst/RAsimpl.v
@@ -6,7 +6,7 @@
   - shift could be shiftn instead, as we often need those, better than using
     addn manually, and the tactic could handle those easily.
 
-**)
+*)
 
 From Stdlib Require Import Utf8 List.
 From LocalComp.autosubst Require Import core unscoped.
@@ -41,7 +41,7 @@ Fixpoint unquote_ren q :=
   | qren_shift => S
   end.
 
-(** Evaluation **)
+(** Evaluation *)
 
 Fixpoint apply_ren (r : quoted_ren) (n : quoted_nat) : quoted_nat :=
   match r, n with
@@ -102,7 +102,7 @@ Definition test_qren_id r : qren_id_view r :=
   | r => not_qren_id r
   end.
 
-(** Correctness **)
+(** Correctness *)
 
 Lemma apply_ren_sound :
   ∀ r n,
@@ -175,7 +175,7 @@ Proof.
       assumption.
 Qed.
 
-(** Quoting **)
+(** Quoting *)
 
 Ltac quote_nat n :=
   lazymatch n with
@@ -215,7 +215,7 @@ Ltac quote_ren r :=
 
   To make it user-extensible, we rely on type classes.
 
-**)
+*)
 
 Create HintDb asimpl_unfold.
 
@@ -267,7 +267,7 @@ Hint Mode RenSimplification + - : typeclass_instances.
   strategy while substitution and renaming simplification performed using the
   the outermost one. We thus use an extra database for the latter.
 
-**)
+*)
 
 Create HintDb asimpl.
 Create HintDb asimpl_outermost.

--- a/theories/autosubst/SubstNotations.v
+++ b/theories/autosubst/SubstNotations.v
@@ -2,7 +2,7 @@
 
   They replace those of Autosubst that are incompatible with list notation.
 
-**)
+*)
 
 From Stdlib Require Import Utf8 List.
 From LocalComp.autosubst Require Import core unscoped RAsimpl AST.


### PR DESCRIPTION
We get rid of indirection while giving more generality to computation rules which could not refer to previous blocks.