### PR TITLE
Get rid of contexts in conversion (and reduction)

### DIFF
--- a/theories/BasicMetaTheory.v
+++ b/theories/BasicMetaTheory.v
@@ -77,16 +77,16 @@ Qed.
 (** Better induction principle for [conversion] *)
 
 Lemma conversion_ind :
-  ∀ (Σ : gctx) Ξ (P : ctx → term → term → Prop),
-    (∀ Γ A t u, P Γ (app (lam A t) u) (t <[ u.. ])) →
-    (∀ Γ c ξ Ξ' A t,
+  ∀ (Σ : gctx) Ξ (P : term → term → Prop),
+    (∀ A t u, P (app (lam A t) u) (t <[ u.. ])) →
+    (∀ c ξ Ξ' A t,
       Σ c = Some (Def Ξ' A t) →
-      inst_equations Σ Ξ Γ ξ Ξ' →
-      inst_equations_ P Γ ξ Ξ' →
+      inst_equations Σ Ξ ξ Ξ' →
+      inst_equations_ P ξ Ξ' →
       closed t = true →
-      P Γ (const c ξ) (inst ξ t)
+      P (const c ξ) (inst ξ t)
     ) →
-    (∀ Γ n rl σ,
+    (∀ n rl σ,
       ictx_get Ξ n = Some (Comp rl) →
       let Θ := rl.(cr_env) in
       let k := length Θ in
@@ -94,48 +94,48 @@ Lemma conversion_ind :
       let rhs := rl.(cr_rep) in
       scoped k lhs = true →
       scoped k rhs = true →
-      P Γ (lhs <[ σ ]) (rhs <[ σ ])
+      P (lhs <[ σ ]) (rhs <[ σ ])
     ) →
-    (∀ Γ A A' B B',
-      Σ ;; Ξ | Γ ⊢ A ≡ A' →
-      P Γ A A' →
-      Σ ;; Ξ | Γ,, A ⊢ B ≡ B' →
-      P (Γ,, A) B B' →
-      P Γ (Pi A B) (Pi A' B')
+    (∀ A A' B B',
+      Σ ;; Ξ ⊢ A ≡ A' →
+      P A A' →
+      Σ ;; Ξ ⊢ B ≡ B' →
+      P B B' →
+      P (Pi A B) (Pi A' B')
     ) →
-    (∀ Γ A A' t t',
-      Σ ;; Ξ | Γ ⊢ A ≡ A' →
-      P Γ A A' →
-      Σ ;; Ξ | Γ,, A ⊢ t ≡ t' →
-      P (Γ,, A) t t' →
-      P Γ (lam A t) (lam A' t')
+    (∀ A A' t t',
+      Σ ;; Ξ ⊢ A ≡ A' →
+      P A A' →
+      Σ ;; Ξ ⊢ t ≡ t' →
+      P t t' →
+      P (lam A t) (lam A' t')
     ) →
-    (∀ Γ u u' v v',
-      Σ ;; Ξ | Γ ⊢ u ≡ u' →
-      P Γ u u' →
-      Σ ;; Ξ | Γ ⊢ v ≡ v' →
-      P Γ v v' →
-      P Γ (app u v) (app u' v')
+    (∀ u u' v v',
+      Σ ;; Ξ ⊢ u ≡ u' →
+      P u u' →
+      Σ ;; Ξ ⊢ v ≡ v' →
+      P v v' →
+      P (app u v) (app u' v')
     ) →
-    (∀ Γ c ξ ξ',
-      Forall2 (option_rel (conversion Σ Ξ Γ)) ξ ξ' →
-      Forall2 (option_rel (P Γ)) ξ ξ' →
-      P Γ (const c ξ) (const c ξ')
+    (∀ c ξ ξ',
+      Forall2 (option_rel (conversion Σ Ξ)) ξ ξ' →
+      Forall2 (option_rel P) ξ ξ' →
+      P (const c ξ) (const c ξ')
     ) →
-    (∀ Γ u, P Γ u u) →
-    (∀ Γ u v, Σ ;; Ξ | Γ ⊢ u ≡ v → P Γ u v → P Γ v u) →
-    (∀ Γ u v w,
-      Σ ;; Ξ | Γ ⊢ u ≡ v →
-      P Γ u v →
-      Σ ;; Ξ | Γ ⊢ v ≡ w →
-      P Γ v w →
-      P Γ u w
+    (∀ u, P u u) →
+    (∀ u v, Σ ;; Ξ ⊢ u ≡ v → P u v → P v u) →
+    (∀ u v w,
+      Σ ;; Ξ ⊢ u ≡ v →
+      P u v →
+      Σ ;; Ξ ⊢ v ≡ w →
+      P v w →
+      P u w
     ) →
-    ∀ Γ u v, Σ ;; Ξ | Γ ⊢ u ≡ v → P Γ u v.
+    ∀ u v, Σ ;; Ξ ⊢ u ≡ v → P u v.
 Proof.
   intros Σ Ξ P hbeta hunfold hred hpi hlam happ hconst hrefl hsym htrans.
-  fix aux 4. move aux at top.
-  intros Γ u v h. destruct h.
+  fix aux 3. move aux at top.
+  intros u v h. destruct h.
   7:{
     eapply hconst. 1: assumption.
     revert ξ ξ' H.
@@ -199,7 +199,7 @@ Lemma typing_ind :
     (∀ Γ i A B t,
       Σ ;; Ξ | Γ ⊢ t : A →
       P Γ t A →
-      Σ ;; Ξ | Γ ⊢ A ≡ B →
+      Σ ;; Ξ ⊢ A ≡ B →
       Σ ;; Ξ | Γ ⊢ B : Sort i →
       P Γ B (Sort i) →
       P Γ t B
@@ -262,27 +262,6 @@ Proof.
   intros h.
   eapply typing_scoped with (Γ := ∙).
   eassumption.
-Qed.
-
-(** Context is irrelevant for conversion
-
-  A bit silly, but it might be better to stick to it in case we want to add more
-  data.
-
-*)
-
-Lemma conv_ctx_irr Σ Ξ Γ Δ u v :
-  Σ ;; Ξ | Γ ⊢ u ≡ v →
-  Σ ;; Ξ | Δ ⊢ u ≡ v.
-Proof.
-  induction 1 using conversion_ind in Δ |- *.
-  all: try solve [ ttconv ].
-  all: try solve [ econstructor ; eauto ].
-  - econstructor. 1,3: eassumption.
-    intros x rl hx. specialize (H1 _ _ hx). cbn in *. intuition eauto.
-  - econstructor. eapply Forall2_impl. 2: eassumption.
-    intros. eapply option_rel_impl. 2: eassumption.
-    intros ??. auto.
 Qed.
 
 (** Renaming preserves typing *)
@@ -530,10 +509,10 @@ Proof.
   cbn. rasimpl. apply closed_ren.
 Qed.
 
-Lemma inst_equations_ren_ih Σ Ξ Γ Δ ρ ξ Ξ' :
-  inst_equations Σ Ξ Γ ξ Ξ' →
-  inst_equations_ (λ _ u v, ∀ Δ ρ, Σ ;; Ξ | Δ ⊢ ρ ⋅ u ≡ ρ ⋅ v) Γ ξ Ξ' →
-  inst_equations Σ Ξ Δ (ren_instance ρ ξ) Ξ'.
+Lemma inst_equations_ren_ih Σ Ξ ρ ξ Ξ' :
+  inst_equations Σ Ξ ξ Ξ' →
+  inst_equations_ (λ u v, ∀ ρ, Σ ;; Ξ ⊢ ρ ⋅ u ≡ ρ ⋅ v) ξ Ξ' →
+  inst_equations Σ Ξ (ren_instance ρ ξ) Ξ'.
 Proof.
   intros h ih.
   intros x rl hx m Θ. cbn.
@@ -542,24 +521,19 @@ Proof.
   specialize (ih _ _ hx) as (e & hl & hr & ih).
   fold m Θ in hl, hr, ih.
   specialize ih with (ρ := uprens m ρ).
-  (* 2:{
-    eapply rtyping_uprens_eq. 1: eassumption.
-    rewrite 2!length_ctx_inst. reflexivity.
-  } *)
   rewrite e. cbn.
   rewrite 2!ren_inst in ih.
   rewrite 2!scoped_ren in ih. 2,3: eassumption.
   intuition eauto.
 Qed.
 
-Lemma conv_ren Σ Ξ Γ Δ ρ u v :
-  (* rtyping Γ ρ Δ → *)
-  Σ ;; Ξ | Δ ⊢ u ≡ v →
-  Σ ;; Ξ | Γ ⊢ ρ ⋅ u ≡ ρ ⋅ v.
+Lemma conv_ren Σ Ξ ρ u v :
+  Σ ;; Ξ ⊢ u ≡ v →
+  Σ ;; Ξ ⊢ ρ ⋅ u ≡ ρ ⋅ v.
 Proof.
-  intros (* hρ *) h.
-  induction h using conversion_ind in Γ, ρ (* , hρ *) |- *.
-  all: try solve [ rasimpl ; econstructor ; eauto using rtyping_up ].
+  intros h.
+  induction h using conversion_ind in ρ |- *.
+  all: try solve [ rasimpl ; econstructor ; eauto ].
   - rasimpl. eapply meta_conv_trans_r. 1: econstructor.
     rasimpl. reflexivity.
   - rasimpl. eapply conv_trans. 1: econstructor. 1,3: eassumption.
@@ -643,10 +617,10 @@ Proof.
 Abort.
 
 (* TODO MOVE *)
-Lemma inst_equations_prop Σ Ξ Γ ξ Ξ' P :
-  inst_equations Σ Ξ Γ ξ Ξ' →
-  (∀ Γ u v, Σ ;; Ξ | Γ ⊢ u ≡ v → P Γ u v) →
-  inst_equations_ P Γ ξ Ξ'.
+Lemma inst_equations_prop Σ Ξ ξ Ξ' P :
+  inst_equations Σ Ξ ξ Ξ' →
+  (∀ u v, Σ ;; Ξ ⊢ u ≡ v → P u v) →
+  inst_equations_ P ξ Ξ'.
 Proof.
   intros h ih.
   intros x rl hx. specialize (h _ _ hx).
@@ -1023,10 +997,10 @@ Proof.
     rasimpl. reflexivity.
 Qed.
 
-Lemma inst_equations_subst_ih Σ Ξ Γ Δ σ ξ Ξ' :
-  inst_equations Σ Ξ Γ ξ Ξ' →
-  inst_equations_ (λ _ u v, ∀ Δ σ, Σ ;; Ξ | Δ ⊢ u <[ σ ] ≡ v <[ σ ]) Γ ξ Ξ' →
-  inst_equations Σ Ξ Δ (subst_instance σ ξ) Ξ'.
+Lemma inst_equations_subst_ih Σ Ξ σ ξ Ξ' :
+  inst_equations Σ Ξ ξ Ξ' →
+  inst_equations_ (λ u v, ∀ σ, Σ ;; Ξ ⊢ u <[ σ ] ≡ v <[ σ ]) ξ Ξ' →
+  inst_equations Σ Ξ (subst_instance σ ξ) Ξ'.
 Proof.
   intros h ih.
   intros x rl hx m Θ. specialize (ih _ _ hx).
@@ -1044,12 +1018,12 @@ Qed.
   It is a bit silly because the context is ignored for conversion (for now).
 
 *)
-Lemma conv_subst Σ Ξ Γ Δ σ u v :
-  Σ ;; Ξ | Δ ⊢ u ≡ v →
-  Σ ;; Ξ | Γ ⊢ u <[ σ ] ≡ v <[ σ ].
+Lemma conv_subst Σ Ξ σ u v :
+  Σ ;; Ξ ⊢ u ≡ v →
+  Σ ;; Ξ ⊢ u <[ σ ] ≡ v <[ σ ].
 Proof.
   intros h.
-  induction h using conversion_ind in Γ, σ |- *.
+  induction h using conversion_ind in σ |- *.
   all: try solve [ rasimpl ; econstructor ; eauto ].
   - rasimpl. eapply meta_conv_trans_r. 1: econstructor.
     rasimpl. reflexivity.
@@ -1383,7 +1357,7 @@ Proof.
   - cbn. apply inst_get.
 Qed.
 
-Lemma liftn_map_map n ξ ξ' :
+Lemma liftn_inst_instance n ξ ξ' :
   liftn n (inst_instance ξ ξ') = inst_instance (liftn n ξ) (liftn n ξ').
 Proof.
   rewrite !map_map. apply map_ext. intro.
@@ -1398,43 +1372,40 @@ Proof.
   - reflexivity.
   - cbn. rewrite ih. f_equal. rewrite inst_inst. f_equal.
     rewrite length_ctx_inst.
-    rewrite liftn_map_map. reflexivity.
+    rewrite liftn_inst_instance. reflexivity.
 Qed.
 
-Lemma inst_equations_inst_ih Σ Ξ Ξ' Ξ'' Γ Δ ξ ξ' :
-  inst_equations Σ Ξ Δ ξ Ξ' →
-  inst_equations Σ Ξ' Γ ξ' Ξ'' →
-  inst_equations_ (λ Γ u v,
-    ∀ Ξ Δ ξ,
-      inst_equations Σ Ξ Δ ξ Ξ' →
-      Σ ;; Ξ | Δ ,,, ctx_inst ξ Γ ⊢ inst (liftn (length Γ) ξ) u ≡ inst (liftn (length Γ) ξ) v
-  ) Γ ξ' Ξ'' →
-  inst_equations Σ Ξ (Δ ,,, ctx_inst ξ Γ) (inst_instance (liftn (length Γ) ξ) ξ') Ξ''.
+Lemma inst_equations_inst_ih Σ Ξ Ξ' Ξ'' k ξ ξ' :
+  inst_equations Σ Ξ ξ Ξ' →
+  inst_equations Σ Ξ' ξ' Ξ'' →
+  inst_equations_ (λ u v,
+    ∀ Ξ p ξ,
+      inst_equations Σ Ξ ξ Ξ' →
+      Σ ;; Ξ ⊢ inst (liftn p ξ) u ≡ inst (liftn p ξ) v
+  ) ξ' Ξ'' →
+  inst_equations Σ Ξ (inst_instance (liftn k ξ) ξ') Ξ''.
 Proof.
   intros hξ h ih.
   intros x rl hx m Θ. specialize (ih _ _ hx) as (e & hl & hr & ih).
   cbn in *. fold m Θ in ih.
-  specialize ih with (1 := hξ).
-  rewrite ctx_inst_app in ih. rewrite <- app_assoc in ih.
-  rewrite ctx_inst_comp in ih.
-  rewrite !length_app in ih. rewrite !length_ctx_inst in ih.
+  specialize ih with (1 := hξ) (p := m + k).
   rewrite !inst_inst in ih.
-  rewrite liftn_map_map.
+  rewrite liftn_inst_instance.
   rewrite liftn_liftn.
   rewrite nth_error_map, e. cbn.
   intuition eauto.
 Qed.
 
-Lemma conv_inst Σ Ξ Ξ' Γ Δ u v ξ :
-  inst_equations Σ Ξ Δ ξ Ξ' →
-  Σ ;; Ξ' | Γ ⊢ u ≡ v →
-  let rξ := liftn (length Γ) ξ in
-  Σ ;; Ξ | Δ ,,, ctx_inst ξ Γ ⊢ inst rξ u ≡ inst rξ v.
+Lemma conv_inst Σ Ξ Ξ' k u v ξ :
+  inst_equations Σ Ξ ξ Ξ' →
+  Σ ;; Ξ' ⊢ u ≡ v →
+  let rξ := liftn k ξ in
+  Σ ;; Ξ ⊢ inst rξ u ≡ inst rξ v.
 Proof.
   intros hξ h. cbn.
-  induction h using conversion_ind in Ξ, Δ, ξ, hξ |- *.
+  induction h using conversion_ind in Ξ, k, ξ, hξ |- *.
   all: try solve [ cbn ; econstructor ; eauto ].
-  - cbn. rewrite subst_inst with (m := S (length Γ)). 2: auto.
+  - cbn. rewrite subst_inst with (m := S k). 2: auto.
     eapply meta_conv_trans_r. 1: constructor.
     cbn. rewrite lift_liftn. apply ext_term. intros []. all: reflexivity.
   - cbn. eapply meta_conv_trans_r.
@@ -1463,13 +1434,13 @@ Proof.
     cbn. auto.
 Qed.
 
-Corollary conv_inst_closed Σ Ξ Ξ' Δ u v ξ :
-  inst_equations Σ Ξ Δ ξ Ξ' →
-  Σ ;; Ξ' | ∙ ⊢ u ≡ v →
-  Σ ;; Ξ | Δ ⊢ inst ξ u ≡ inst ξ v.
+Corollary conv_inst_closed Σ Ξ Ξ' u v ξ :
+  inst_equations Σ Ξ ξ Ξ' →
+  Σ ;; Ξ' ⊢ u ≡ v →
+  Σ ;; Ξ ⊢ inst ξ u ≡ inst ξ v.
 Proof.
   intros hξ h.
-  eapply conv_inst in h. 2: eassumption.
+  eapply conv_inst with (k := 0) in h. 2: eassumption.
   cbn in h. rewrite ren_instance_id_ext in h. 2: auto.
   assumption.
 Qed.
@@ -1545,12 +1516,12 @@ Proof.
   assumption.
 Qed.
 
-Lemma conv_insts Σ Ξ Γ t ξ ξ' :
-  Forall2 (option_rel (conversion Σ Ξ Γ)) ξ ξ' →
-  Σ ;; Ξ | Γ ⊢ inst ξ t ≡ inst ξ' t.
+Lemma conv_insts Σ Ξ t ξ ξ' :
+  Forall2 (option_rel (conversion Σ Ξ)) ξ ξ' →
+  Σ ;; Ξ ⊢ inst ξ t ≡ inst ξ' t.
 Proof.
   intros hξ.
-  induction t using term_rect in Γ, ξ, ξ', hξ |- *.
+  induction t using term_rect in ξ, ξ', hξ |- *.
   all: try solve [ cbn ; ttconv ].
   - cbn. eapply cong_Pi. 1: eauto.
     eapply IHt2. eapply Forall2_map_l, Forall2_map_r.
@@ -1590,11 +1561,11 @@ Proof.
     assumption.
 Qed.
 
-Lemma cong_inst Σ Ξ Γ u v ξ ξ' Ξ' :
-  inst_equations Σ Ξ Γ ξ Ξ' →
-  Σ ;; Ξ' | ∙ ⊢ u ≡ v →
-  Forall2 (option_rel (conversion Σ Ξ Γ)) ξ ξ' →
-  Σ ;; Ξ | Γ ⊢ inst ξ u ≡ inst ξ' v.
+Lemma cong_inst Σ Ξ u v ξ ξ' Ξ' :
+  inst_equations Σ Ξ ξ Ξ' →
+  Σ ;; Ξ' ⊢ u ≡ v →
+  Forall2 (option_rel (conversion Σ Ξ)) ξ ξ' →
+  Σ ;; Ξ ⊢ inst ξ u ≡ inst ξ' v.
 Proof.
   intros hξ h hh.
   eapply conv_trans.
@@ -1611,9 +1582,9 @@ Proof.
   apply lvl_get_weak.
 Qed.
 
-Lemma conv_eweak Σ Ξ d Γ u v :
-  Σ ;; Ξ | Γ ⊢ u ≡ v →
-  Σ ;; d :: Ξ | Γ ⊢ u ≡ v.
+Lemma conv_eweak Σ Ξ d u v :
+  Σ ;; Ξ ⊢ u ≡ v →
+  Σ ;; d :: Ξ ⊢ u ≡ v.
 Proof.
   intros h. induction h using conversion_ind.
   all: try solve [ econstructor ; eauto ].
@@ -1621,9 +1592,9 @@ Proof.
   apply ictx_get_weak. eassumption.
 Qed.
 
-Lemma inst_equations_eweak Σ Ξ d Γ ξ Ξ' :
-  inst_equations Σ Ξ Γ ξ Ξ' →
-  inst_equations Σ (d :: Ξ) Γ ξ Ξ'.
+Lemma inst_equations_eweak Σ Ξ d ξ Ξ' :
+  inst_equations Σ Ξ ξ Ξ' →
+  inst_equations Σ (d :: Ξ) ξ Ξ'.
 Proof.
   intros h.
   intros x rl hx. specialize (h _ _ hx).
@@ -1703,29 +1674,29 @@ Qed.
 
 (** Global environment weakening *)
 
-Lemma inst_equations_gweak_ih Σ Σ' Ξ Γ ξ Ξ' :
+Lemma inst_equations_gweak_ih Σ Σ' Ξ ξ Ξ' :
   Σ ⊑ Σ' →
-  inst_equations_ (λ Γ u v, Σ' ;; Ξ | Γ ⊢ u ≡ v) Γ ξ Ξ' →
-  inst_equations Σ' Ξ Γ ξ Ξ'.
+  inst_equations_ (λ u v, Σ' ;; Ξ ⊢ u ≡ v) ξ Ξ' →
+  inst_equations Σ' Ξ ξ Ξ'.
 Proof.
   intros hle ih.
   intros x rl hx. specialize (ih _ _ hx).
   intuition eauto.
 Qed.
 
-Lemma conv_gweak Σ Σ' Ξ Γ u v :
-  Σ ;; Ξ | Γ ⊢ u ≡ v →
+Lemma conv_gweak Σ Σ' Ξ u v :
+  Σ ;; Ξ ⊢ u ≡ v →
   Σ ⊑ Σ' →
-  Σ' ;; Ξ | Γ ⊢ u ≡ v.
+  Σ' ;; Ξ ⊢ u ≡ v.
 Proof.
   intros h hle. induction h using conversion_ind.
   all: solve [ econstructor ; eauto ].
 Qed.
 
-Lemma inst_equations_gweak Σ Σ' Ξ Γ ξ Ξ' :
-  inst_equations Σ Ξ Γ ξ Ξ' →
+Lemma inst_equations_gweak Σ Σ' Ξ ξ Ξ' :
+  inst_equations Σ Ξ ξ Ξ' →
   Σ ⊑ Σ' →
-  inst_equations Σ' Ξ Γ ξ Ξ'.
+  inst_equations Σ' Ξ ξ Ξ'.
 Proof.
   intros h hle.
   eauto using inst_equations_gweak_ih, inst_equations_prop, conv_gweak.
@@ -2106,7 +2077,7 @@ Lemma typing_ind_wf :
       wf Σ Ξ Γ →
       Σ ;; Ξ | Γ ⊢ t : A →
       P Γ t A →
-      Σ ;; Ξ | Γ ⊢ A ≡ B →
+      Σ ;; Ξ ⊢ A ≡ B →
       Σ ;; Ξ | Γ ⊢ B : Sort i →
       P Γ B (Sort i) →
       P Γ t B

--- a/theories/Inlining.v
+++ b/theories/Inlining.v
@@ -156,13 +156,13 @@ Section Inline.
   Definition g_conv_unfold :=
     ∀ c Ξ' A t,
       Σ c = Some (Def Ξ' A t) →
-      [] ;; ⟦ Ξ' ⟧e | ∙ ⊢ κ c ≡ ⟦ t ⟧.
+      [] ;; ⟦ Ξ' ⟧e ⊢ κ c ≡ ⟦ t ⟧.
 
   Context (h_conv_unfold : g_conv_unfold).
 
-  Lemma conv_ren_inst Ξ Γ Δ ρ ξ ξ' :
-    Forall2 (option_rel (conversion Σ Ξ Δ)) ξ ξ' →
-    Forall2 (option_rel (conversion Σ Ξ Γ)) (ren_instance ρ ξ) (ren_instance ρ ξ').
+  Lemma conv_ren_inst Ξ ρ ξ ξ' :
+    Forall2 (option_rel (conversion Σ Ξ)) ξ ξ' →
+    Forall2 (option_rel (conversion Σ Ξ)) (ren_instance ρ ξ) (ren_instance ρ ξ').
   Proof.
     intros h.
     apply Forall2_map_l, Forall2_map_r.
@@ -248,9 +248,9 @@ Section Inline.
       rewrite inline_ren_instance. rewrite length_map. reflexivity.
   Qed.
 
-  Lemma inst_equations_inline_ih Ξ Ξ' Γ ξ :
-    inst_equations_ (λ Γ u v, [] ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ u ⟧ ≡ ⟦ v ⟧) Γ ξ Ξ' →
-    inst_equations [] ⟦ Ξ ⟧e ⟦ Γ ⟧* ⟦ ξ ⟧× ⟦ Ξ' ⟧e.
+  Lemma inst_equations_inline_ih Ξ Ξ' ξ :
+    inst_equations_ (λ u v, [] ;; ⟦ Ξ ⟧e ⊢ ⟦ u ⟧ ≡ ⟦ v ⟧) ξ Ξ' →
+    inst_equations [] ⟦ Ξ ⟧e ⟦ ξ ⟧× ⟦ Ξ' ⟧e.
   Proof.
     intros ih.
     intros x rl hx.
@@ -260,7 +260,6 @@ Section Inline.
     specialize (ih _ _ hx') as (hx & hl & hr & ih).
     cbn. rewrite nth_error_map, hx. cbn.
     rewrite !length_map.
-    rewrite map_app in ih. rewrite !inline_ctx_inst in ih.
     rewrite !inline_inst in ih. rewrite !inline_ren_instance in ih.
     intuition eauto using scoped_inline.
   Qed.
@@ -277,9 +276,9 @@ Section Inline.
     reflexivity.
   Qed.
 
-  Lemma conv_inline Ξ Γ u v :
-    Σ ;; Ξ | Γ ⊢ u ≡ v →
-    [] ;; ⟦ Ξ ⟧e | ⟦ Γ ⟧* ⊢ ⟦ u ⟧ ≡ ⟦ v ⟧.
+  Lemma conv_inline Ξ u v :
+    Σ ;; Ξ ⊢ u ≡ v →
+    [] ;; ⟦ Ξ ⟧e ⊢ ⟦ u ⟧ ≡ ⟦ v ⟧.
   Proof.
     intros h.
     induction h using conversion_ind.

--- a/theories/Inversion.v
+++ b/theories/Inversion.v
@@ -47,14 +47,14 @@ Lemma type_var_inv Σ Ξ Γ x A :
   Σ ;; Ξ | Γ ⊢ var x : A →
   ∃ B,
     nth_error Γ x = Some B ∧
-    Σ ;; Ξ | Γ ⊢ (plus (S x)) ⋅ B ≡ A.
+    Σ ;; Ξ ⊢ (plus (S x)) ⋅ B ≡ A.
 Proof.
   intros h. invtac h.
 Qed.
 
 Lemma type_sort_inv Σ Ξ Γ i A :
   Σ ;; Ξ | Γ ⊢ Sort i : A →
-  Σ ;; Ξ | Γ ⊢ Sort (S i) ≡ A.
+  Σ ;; Ξ ⊢ Sort (S i) ≡ A.
 Proof.
   intros h. invtac h.
 Qed.
@@ -64,7 +64,7 @@ Lemma type_pi_inv Σ Ξ Γ A B T :
   ∃ i j,
     Σ ;; Ξ | Γ ⊢ A : Sort i ∧
     Σ ;; Ξ | Γ ,, A ⊢ B : Sort j ∧
-    Σ ;; Ξ | Γ ⊢ Sort (max i j) ≡ T.
+    Σ ;; Ξ ⊢ Sort (max i j) ≡ T.
 Proof.
   intros h. invtac h.
 Qed.
@@ -75,7 +75,7 @@ Lemma type_lam_inv Σ Ξ Γ A t T :
     Σ ;; Ξ | Γ ⊢ A : Sort i ∧
     Σ ;; Ξ | Γ ,, A ⊢ B : Sort j ∧
     Σ ;; Ξ | Γ ,, A ⊢ t : B ∧
-    Σ ;; Ξ | Γ ⊢ Pi A B ≡ T.
+    Σ ;; Ξ ⊢ Pi A B ≡ T.
 Proof.
   intros h. invtac h.
 Qed.
@@ -87,7 +87,7 @@ Lemma type_app_inv Σ Ξ Γ u v T :
     Σ ;; Ξ | Γ ⊢ v : A ∧
     Σ ;; Ξ | Γ ⊢ A : Sort i ∧
     Σ ;; Ξ | Γ ,, A ⊢ B : Sort j ∧
-    Σ ;; Ξ | Γ ⊢ B <[ v .. ] ≡ T.
+    Σ ;; Ξ ⊢ B <[ v .. ] ≡ T.
 Proof.
   intros h. invtac h.
 Qed.
@@ -98,7 +98,7 @@ Lemma type_const_inv Σ Ξ Γ c ξ T :
     Σ c = Some (Def Ξ' A t) ∧
     inst_typing Σ Ξ Γ ξ Ξ' ∧
     closed A = true ∧
-    Σ ;; Ξ | Γ ⊢ inst ξ A ≡ T.
+    Σ ;; Ξ ⊢ inst ξ A ≡ T.
 Proof.
   intros h. invtac h.
 Qed.
@@ -108,7 +108,7 @@ Lemma type_assm_inv Σ Ξ Γ x T :
   ∃ A,
     ictx_get Ξ x = Some (Assm A) ∧
     closed A = true ∧
-    Σ ;; Ξ | Γ ⊢ A ≡ T.
+    Σ ;; Ξ ⊢ A ≡ T.
 Proof.
   intros h. invtac h.
 Qed.

--- a/theories/Pattern.v
+++ b/theories/Pattern.v
@@ -143,133 +143,133 @@ Definition triangle_citerion Ξ :=
 
 Section Red.
 
-  Reserved Notation "Γ ⊢ u ⇒ v"
-    (at level 80, u, v at next level).
+  Reserved Notation "u ⇒ v"
+    (at level 80).
 
   Context (Σ : gctx) (Ξ : pctx).
 
-  Inductive pred (Γ : ctx) : term → term → Prop :=
+  Inductive pred : term → term → Prop :=
 
   (** Computation rules *)
 
   | pred_beta A t t' u u' :
-      Γ ,, A ⊢ t ⇒ t' →
-      Γ ⊢ u ⇒ u' →
-      Γ ⊢ app (lam A t) u ⇒ t' <[ u' .. ]
+      t ⇒ t' →
+      u ⇒ u' →
+      app (lam A t) u ⇒ t' <[ u' .. ]
 
   | pred_unfold c ξ Ξ' A t ξ' :
       Σ c = Some (Def Ξ' A t) →
       closed t = true →
-      Forall2 (option_rel (pred Γ)) ξ ξ' →
-      Γ ⊢ const c ξ ⇒ inst ξ' t
+      Forall2 (option_rel pred) ξ ξ' →
+      const c ξ ⇒ inst ξ' t
 
   | pred_rule n rl t σ σ' :
       pctx_get Ξ n = Some (pComp rl) →
       match_pat rl.(pr_pat) t = Some σ →
-      Forall2 (pred Γ) σ σ' →
+      Forall2 pred σ σ' →
       let rhs := rl.(pr_rep) in
       (* let Θ := rl.(pr_env) in *)
       (* let k := length Θ in
       let lhs := rl.(cr_pat) in
       scoped k lhs = true →
       scoped k rhs = true → *)
-      Γ ⊢ t ⇒ rhs <[ slist σ' ]
+      t ⇒ rhs <[ slist σ' ]
 
   (** Congruence rules *)
 
   | pred_Pi A B A' B' :
-      Γ ⊢ A ⇒ A' →
-      Γ ,, A ⊢ B ⇒ B' →
-      Γ ⊢ Pi A B ⇒ Pi A' B'
+      A ⇒ A' →
+      B ⇒ B' →
+      Pi A B ⇒ Pi A' B'
 
   | pred_lam A t A' t' :
-      Γ ⊢ A ⇒ A' →
-      Γ ,, A ⊢ t ⇒ t' →
-      Γ ⊢ lam A t ⇒ lam A' t'
+      A ⇒ A' →
+      t ⇒ t' →
+      lam A t ⇒ lam A' t'
 
   | pred_app u v u' v' :
-      Γ ⊢ u ⇒ u' →
-      Γ ⊢ v ⇒ v' →
-      Γ ⊢ app u v ⇒ app u' v'
+      u ⇒ u' →
+      v ⇒ v' →
+      app u v ⇒ app u' v'
 
   | pred_const c ξ ξ' :
-      Forall2 (option_rel (pred Γ)) ξ ξ' →
-      Γ ⊢ const c ξ ⇒ const c ξ'
+      Forall2 (option_rel pred) ξ ξ' →
+      const c ξ ⇒ const c ξ'
 
   | pred_var x :
-      Γ ⊢ var x ⇒ var x
+      var x ⇒ var x
 
   | pred_sort s :
-      Γ ⊢ Sort s ⇒ Sort s
+      Sort s ⇒ Sort s
 
   | pred_assm x :
-      Γ ⊢ assm x ⇒ assm x
+      assm x ⇒ assm x
 
-  where "Γ ⊢ u ⇒ v" := (pred Γ u v).
+  where "u ⇒ v" := (pred u v).
 
   Lemma pred_ind_alt :
-    ∀ (P : ctx → term → term → Prop),
-      (∀ Γ A t t' u u',
-        Γ,, A ⊢ t ⇒ t' →
-        P (Γ,, A) t t' →
-        Γ ⊢ u ⇒ u' →
-        P Γ u u' →
-        P Γ (app (lam A t) u) (t' <[ u'..])
+    ∀ (P : term → term → Prop),
+      (∀ A t t' u u',
+        t ⇒ t' →
+        P t t' →
+        u ⇒ u' →
+        P u u' →
+        P (app (lam A t) u) (t' <[ u'..])
       ) →
-      (∀ Γ c ξ Ξ' A t ξ',
+      (∀ c ξ Ξ' A t ξ',
         Σ c = Some (Def Ξ' A t) →
         closed t = true →
-        Forall2 (option_rel (pred Γ)) ξ ξ' →
-        Forall2 (option_rel (P Γ)) ξ ξ' →
-        P Γ (const c ξ) (inst ξ' t)
+        Forall2 (option_rel pred) ξ ξ' →
+        Forall2 (option_rel P) ξ ξ' →
+        P (const c ξ) (inst ξ' t)
       ) →
-      (∀ Γ n rl t σ σ',
+      (∀ n rl t σ σ',
         pctx_get Ξ n = Some (pComp rl) →
         match_pat rl.(pr_pat) t = Some σ →
-        Forall2 (pred Γ) σ σ' →
-        Forall2 (P Γ) σ σ' →
+        Forall2 pred σ σ' →
+        Forall2 P σ σ' →
         let rhs := rl.(pr_rep) in
         (* let Θ := rl.(pr_env) in *)
         (* let k := length Θ in
         let lhs := rl.(cr_pat) in
         scoped k lhs = true →
         scoped k rhs = true → *)
-        P Γ t (rhs <[ slist σ' ])
+        P t (rhs <[ slist σ' ])
       ) →
-      (∀ Γ A B A' B',
-        Γ ⊢ A ⇒ A' →
-        P Γ A A' →
-        Γ,, A ⊢ B ⇒ B' →
-        P (Γ,, A) B B' →
-        P Γ (Pi A B) (Pi A' B')
+      (∀ A B A' B',
+        A ⇒ A' →
+        P A A' →
+        B ⇒ B' →
+        P B B' →
+        P (Pi A B) (Pi A' B')
       ) →
-      (∀ Γ A t A' t',
-        Γ ⊢ A ⇒ A' →
-        P Γ A A' →
-        Γ,, A ⊢ t ⇒ t' →
-        P (Γ,, A) t t' →
-        P Γ (lam A t) (lam A' t')
+      (∀ A t A' t',
+        A ⇒ A' →
+        P A A' →
+        t ⇒ t' →
+        P t t' →
+        P (lam A t) (lam A' t')
       ) →
-      (∀ Γ u v u' v',
-        Γ ⊢ u ⇒ u' →
-        P Γ u u' →
-        Γ ⊢ v ⇒ v' →
-        P Γ v v' →
-        P Γ (app u v) (app u' v')
+      (∀ u v u' v',
+        u ⇒ u' →
+        P u u' →
+        v ⇒ v' →
+        P v v' →
+        P (app u v) (app u' v')
       ) →
-      (∀ Γ c ξ ξ',
-        Forall2 (option_rel (pred Γ)) ξ ξ' →
-        Forall2 (option_rel (P Γ)) ξ ξ' →
-        P Γ (const c ξ) (const c ξ')
+      (∀ c ξ ξ',
+        Forall2 (option_rel pred) ξ ξ' →
+        Forall2 (option_rel P) ξ ξ' →
+        P (const c ξ) (const c ξ')
       ) →
-      (∀ Γ x, P Γ (var x) (var x)) →
-      (∀ Γ s, P Γ (Sort s) (Sort s)) →
-      (∀ Γ x, P Γ (assm x) (assm x)) →
-      ∀ Γ u v, Γ ⊢ u ⇒ v → P Γ u v.
+      (∀ x, P (var x) (var x)) →
+      (∀ s, P (Sort s) (Sort s)) →
+      (∀ x, P (assm x) (assm x)) →
+      ∀ u v, u ⇒ v → P u v.
   Proof.
     intros P hbeta hunf hrl hpi hlam happ hconst hvar hsort hassm.
-    fix aux 4. move aux at top.
-    intros Γ u v h. destruct h.
+    fix aux 3. move aux at top.
+    intros u v h. destruct h.
     7:{
       eapply hconst. 1: assumption.
       revert ξ ξ' H. fix aux1 3.
@@ -298,55 +298,26 @@ Section Red.
     all: eauto.
   Qed.
 
-  Lemma pred_meta_r Γ u v v' :
-    Γ ⊢ u ⇒ v →
+  Lemma pred_meta_r u v v' :
+    u ⇒ v →
     v = v' →
-    Γ ⊢ u ⇒ v'.
+    u ⇒ v'.
   Proof.
     intros ? ->. assumption.
   Qed.
 
   (** ** Parallel reduction is reflexive *)
 
-  Lemma pred_refl Γ t :
-    Γ ⊢ t ⇒ t.
+  Lemma pred_refl t :
+    t ⇒ t.
   Proof.
-    induction t using term_rect in Γ |- *.
+    induction t using term_rect.
     all: try solve [ econstructor ; eauto ].
     econstructor. apply Forall2_diag. apply All_Forall.
     eapply All_impl. 2: eassumption.
     intros o ho. apply option_rel_diag. rewrite OnSome_onSome.
     apply onSomeT_onSome. eapply onSomeT_impl. 2: eassumption.
     auto.
-  Qed.
-
-  (** ** Parallel reduction doesn't care about contexts
-
-    This can feel a bit silly, but we would need to care about contexts if we
-    were to extend the theory with let bindings.
-    In the meantime, we allow ourselves to forget about the context from time to
-    time.
-
-  *)
-
-  Lemma pred_ctx_irr Γ Δ u v :
-    Γ ⊢ u ⇒ v →
-    Δ ⊢ u ⇒ v.
-  Proof.
-    intros h.
-    induction h in Δ |- * using pred_ind_alt.
-    all: try solve [ econstructor ; eauto ].
-    - econstructor. 1,2: eassumption.
-      eapply Forall2_impl. 2: eassumption.
-      intros. eapply option_rel_impl. 2: eassumption.
-      auto.
-    - econstructor. 1,2: eassumption.
-      eapply Forall2_impl. 2: eassumption.
-      auto.
-    - econstructor.
-      eapply Forall2_impl. 2: eassumption.
-      intros. eapply option_rel_impl. 2: eassumption.
-      auto.
   Qed.
 
   (** ** Parallel reduction is stable by substitution *)
@@ -374,12 +345,12 @@ Section Red.
       + cbn. eauto.
   Qed.
 
-  Lemma pred_ren Γ Δ ρ u v :
-    Γ ⊢ u ⇒ v →
-    Δ ⊢ ρ ⋅ u ⇒ ρ ⋅ v.
+  Lemma pred_ren ρ u v :
+    u ⇒ v →
+    ρ ⋅ u ⇒ ρ ⋅ v.
   Proof.
     intros h.
-    induction h in Δ, ρ |- * using pred_ind_alt.
+    induction h in ρ |- * using pred_ind_alt.
     all: try solve [ rasimpl ; econstructor ; eauto ].
     - rasimpl. eapply pred_meta_r.
       + econstructor. all: eauto.
@@ -410,9 +381,9 @@ Section Red.
       cbn. auto.
   Qed.
 
-  Lemma pred_subst_up Δ A σ σ' :
-    (∀ x, Δ ⊢ σ x ⇒ σ' x) →
-    (∀ x, Δ ,, A <[ σ ] ⊢ (var 0 .: σ >> ren_term S) x ⇒ (var 0 .: σ' >> ren_term S) x).
+  Lemma pred_subst_up σ σ' :
+    (∀ x, σ x ⇒ σ' x) →
+    (∀ x, (var 0 .: σ >> ren_term S) x ⇒ (var 0 .: σ' >> ren_term S) x).
   Proof.
     intros h x.
     destruct x.
@@ -443,13 +414,13 @@ Section Red.
       + cbn. eauto.
   Qed.
 
-  Lemma pred_subst Γ Δ σ σ' u v :
-    (∀ x, Δ ⊢ σ x ⇒ σ' x) →
-    Γ ⊢ u ⇒ v →
-    Δ ⊢ u <[ σ ] ⇒ v <[ σ' ].
+  Lemma pred_subst σ σ' u v :
+    (∀ x, σ x ⇒ σ' x) →
+    u ⇒ v →
+    u <[ σ ] ⇒ v <[ σ' ].
   Proof.
     intros hσ h.
-    induction h in Δ, σ, σ', hσ |- * using pred_ind_alt.
+    induction h in σ, σ', hσ |- * using pred_ind_alt.
     all: try solve [ rasimpl ; econstructor ; eauto using pred_subst_up ].
     - rasimpl. eapply pred_meta_r.
       + econstructor. all: eauto using pred_subst_up.
@@ -480,9 +451,9 @@ Section Red.
     - cbn. eauto.
   Qed.
 
-  Lemma lift_instance_pred Γ A ξ ξ' :
-    Forall2 (option_rel (pred Γ)) ξ ξ' →
-    Forall2 (option_rel (pred (Γ ,, inst ξ A))) (lift_instance ξ) (lift_instance ξ').
+  Lemma lift_instance_pred ξ ξ' :
+    Forall2 (option_rel pred) ξ ξ' →
+    Forall2 (option_rel pred) (lift_instance ξ) (lift_instance ξ').
   Proof.
     intros h.
     apply Forall2_map_l, Forall2_map_r.
@@ -493,12 +464,12 @@ Section Red.
     intros. eauto using pred_ren.
   Qed.
 
-  Lemma pred_inst Γ ξ ξ' t :
-    Forall2 (option_rel (pred Γ)) ξ ξ' →
-    Γ ⊢ inst ξ t ⇒ inst ξ' t.
+  Lemma pred_inst ξ ξ' t :
+    Forall2 (option_rel pred) ξ ξ' →
+    inst ξ t ⇒ inst ξ' t.
   Proof.
     intros h.
-    induction t using term_rect in Γ, ξ, ξ', h |- *.
+    induction t using term_rect in ξ, ξ', h |- *.
     all: try solve [ cbn ; constructor ; eauto using lift_instance_pred ].
     - cbn. econstructor.
       apply Forall2_map_l, Forall2_map_r.
@@ -554,147 +525,147 @@ Section Red.
     intuition congruence.
   Qed.
 
-  Reserved Notation "Γ ⊢ u ⇒ᵨ v"
-    (at level 80, u, v at next level).
+  Reserved Notation "u ⇒ᵨ v"
+    (at level 80).
 
-  Inductive pred_max Γ : term → term → Prop :=
+  Inductive pred_max : term → term → Prop :=
   | pred_max_beta A t t' u u' :
       no_match Ξ (app (lam A t) u) →
-      Γ ,, A ⊢ t ⇒ᵨ t' →
-      Γ ⊢ u ⇒ᵨ u' →
-      Γ ⊢ app (lam A t) u ⇒ᵨ t' <[ u' .. ]
+      t ⇒ᵨ t' →
+      u ⇒ᵨ u' →
+      app (lam A t) u ⇒ᵨ t' <[ u' .. ]
 
   | pred_max_unfold c ξ Ξ' A t ξ' :
       no_match Ξ (const c ξ) →
       cst_def c = Some (Ξ', A, t) →
-      Forall2 (option_rel (pred_max Γ)) ξ ξ' →
-      Γ ⊢ const c ξ ⇒ᵨ inst ξ' t
+      Forall2 (option_rel pred_max) ξ ξ' →
+      const c ξ ⇒ᵨ inst ξ' t
 
   | pred_max_Pi A B A' B' :
       no_match Ξ (Pi A B) →
-      Γ ⊢ A ⇒ᵨ A' →
-      Γ ,, A ⊢ B ⇒ᵨ B' →
-      Γ ⊢ Pi A B ⇒ᵨ Pi A' B'
+      A ⇒ᵨ A' →
+      B ⇒ᵨ B' →
+      Pi A B ⇒ᵨ Pi A' B'
 
   | pred_max_lam A t A' t' :
       no_match Ξ (lam A t) →
-      Γ ⊢ A ⇒ᵨ A' →
-      Γ ,, A ⊢ t ⇒ᵨ t' →
-      Γ ⊢ lam A t ⇒ᵨ lam A' t'
+      A ⇒ᵨ A' →
+      t ⇒ᵨ t' →
+      lam A t ⇒ᵨ lam A' t'
 
   | pred_max_app u v u' v' :
       is_lam u = false →
       no_match Ξ (app u v) →
-      Γ ⊢ u ⇒ᵨ u' →
-      Γ ⊢ v ⇒ᵨ v' →
-      Γ ⊢ app u v ⇒ᵨ app u' v'
+      u ⇒ᵨ u' →
+      v ⇒ᵨ v' →
+      app u v ⇒ᵨ app u' v'
 
   | pred_max_const c ξ ξ' :
       no_match Ξ (const c ξ) →
       cst_def c = None →
-      Forall2 (option_rel (pred_max Γ)) ξ ξ' →
-      Γ ⊢ const c ξ ⇒ᵨ const c ξ'
+      Forall2 (option_rel pred_max) ξ ξ' →
+      const c ξ ⇒ᵨ const c ξ'
 
   | pred_max_var x :
       no_match Ξ (var x) →
-      Γ ⊢ var x ⇒ᵨ var x
+      var x ⇒ᵨ var x
 
   | pred_max_sort s :
       no_match Ξ (Sort s) →
-      Γ ⊢ Sort s ⇒ᵨ Sort s
+      Sort s ⇒ᵨ Sort s
 
   | pred_max_assm x :
       no_match Ξ (assm x) →
-      Γ ⊢ assm x ⇒ᵨ assm x
+      assm x ⇒ᵨ assm x
 
   | pred_max_rule n rl t σ σ' :
       pctx_get Ξ n = Some (pComp rl) →
       match_pat rl.(pr_pat) t = Some σ →
-      Forall2 (pred_max Γ) σ σ' →
+      Forall2 pred_max σ σ' →
       let rhs := rl.(pr_rep) in
       (* let Θ := rl.(cr_env) in
       let k := length Θ in
       let lhs := rl.(cr_pat) in
       scoped k lhs = true →
       scoped k rhs = true → *)
-      Γ ⊢ t ⇒ᵨ rhs <[ slist σ' ]
+      t ⇒ᵨ rhs <[ slist σ' ]
 
-  where "Γ ⊢ u ⇒ᵨ v" := (pred_max Γ u v).
+  where "u ⇒ᵨ v" := (pred_max u v).
 
   Lemma pred_max_ind_alt :
-    ∀ (P : list term → term → term → Prop),
-      (∀ Γ A t t' u u',
+    ∀ (P : term → term → Prop),
+      (∀ A t t' u u',
         no_match Ξ (app (lam A t) u) →
-        Γ,, A ⊢ t ⇒ᵨ t' →
-        P (Γ,, A) t t' →
-        Γ ⊢ u ⇒ᵨ u' →
-        P Γ u u' →
-        P Γ (app (lam A t) u) (t' <[ u'..])
+        t ⇒ᵨ t' →
+        P t t' →
+        u ⇒ᵨ u' →
+        P u u' →
+        P (app (lam A t) u) (t' <[ u'..])
       ) →
-      (∀ Γ c ξ Ξ' A t ξ',
+      (∀ c ξ Ξ' A t ξ',
         no_match Ξ (const c ξ) →
         cst_def c = Some (Ξ', A, t) →
-        Forall2 (option_rel (pred_max Γ)) ξ ξ' →
-        Forall2 (option_rel (P Γ)) ξ ξ' →
-        P Γ (const c ξ) (inst ξ' t)
+        Forall2 (option_rel pred_max) ξ ξ' →
+        Forall2 (option_rel P) ξ ξ' →
+        P (const c ξ) (inst ξ' t)
       ) →
-      (∀ Γ A B A' B',
+      (∀ A B A' B',
         no_match Ξ (Pi A B) →
-        Γ ⊢ A ⇒ᵨ A' →
-        P Γ A A' →
-        Γ,, A ⊢ B ⇒ᵨ B' →
-        P (Γ,, A) B B' →
-        P Γ (Pi A B) (Pi A' B')
+        A ⇒ᵨ A' →
+        P A A' →
+        B ⇒ᵨ B' →
+        P B B' →
+        P (Pi A B) (Pi A' B')
       ) →
-      (∀ Γ A t A' t',
+      (∀ A t A' t',
         no_match Ξ (lam A t) →
-        Γ ⊢ A ⇒ᵨ A' →
-        P Γ A A' →
-        Γ,, A ⊢ t ⇒ᵨ t' →
-        P (Γ,, A) t t' →
-        P Γ (lam A t) (lam A' t')
+        A ⇒ᵨ A' →
+        P A A' →
+        t ⇒ᵨ t' →
+        P t t' →
+        P (lam A t) (lam A' t')
       ) →
-      (∀ Γ u v u' v',
+      (∀ u v u' v',
         is_lam u = false →
         no_match Ξ (app u v) →
-        Γ ⊢ u ⇒ᵨ u' →
-        P Γ u u' →
-        Γ ⊢ v ⇒ᵨ v' →
-        P Γ v v' →
-        P Γ (app u v) (app u' v')
+        u ⇒ᵨ u' →
+        P u u' →
+        v ⇒ᵨ v' →
+        P v v' →
+        P (app u v) (app u' v')
       ) →
-      (∀ Γ c ξ ξ',
+      (∀ c ξ ξ',
         no_match Ξ (const c ξ) →
         cst_def c = None →
-        Forall2 (option_rel (pred_max Γ)) ξ ξ' →
-        Forall2 (option_rel (P Γ)) ξ ξ' →
-        P Γ (const c ξ) (const c ξ')
+        Forall2 (option_rel pred_max) ξ ξ' →
+        Forall2 (option_rel P) ξ ξ' →
+        P (const c ξ) (const c ξ')
       ) →
-      (∀ Γ x,
+      (∀ x,
         no_match Ξ (var x) →
-        P Γ (var x) (var x)
+        P (var x) (var x)
       ) →
-      (∀ Γ s,
+      (∀ s,
         no_match Ξ (Sort s) →
-        P Γ (Sort s) (Sort s)
+        P (Sort s) (Sort s)
       ) →
-      (∀ Γ x,
+      (∀ x,
         no_match Ξ (assm x) →
-        P Γ (assm x) (assm x)
+        P (assm x) (assm x)
       ) →
-      (∀ Γ n rl t σ σ',
+      (∀ n rl t σ σ',
         pctx_get Ξ n = Some (pComp rl) →
         match_pat rl.(pr_pat) t = Some σ →
-        Forall2 (pred_max Γ) σ σ' →
-        Forall2 (P Γ) σ σ' →
+        Forall2 pred_max σ σ' →
+        Forall2 P σ σ' →
         let rhs := rl.(pr_rep) in
-        P Γ t (rhs <[ slist σ'])
+        P t (rhs <[ slist σ'])
       ) →
-      ∀ Γ u v, Γ ⊢ u ⇒ᵨ v → P Γ u v.
+      ∀ u v, u ⇒ᵨ v → P u v.
   Proof.
     intros P hbeta hunf hpi hlam happ hcst hvar hsort hassm hrl.
-    fix aux 4. move aux at top.
-    intros Γ u v h. destruct h.
+    fix aux 3. move aux at top.
+    intros u v h. destruct h.
     10:{
       eapply hrl. 1-4: eauto.
       clear H0.
@@ -927,21 +898,21 @@ Section Red.
     intuition reflexivity.
   Qed.
 
-  Lemma triangle Γ t u :
-    Γ ⊢ t ⇒ u →
-    ∃ tᵨ, Γ ⊢ t ⇒ᵨ tᵨ ∧ Γ ⊢ u ⇒ tᵨ.
+  Lemma triangle t u :
+    t ⇒ u →
+    ∃ tᵨ, t ⇒ᵨ tᵨ ∧ u ⇒ tᵨ.
   Proof.
     induction 1 as [
-      ?????? ht iht hu ihu
-    | ????????? iht ihξ
-    | ???????? hσ ih ?
-    | ?????? ihA ? ihB
-    | ?????? ihA ? iht
-    | ? u ??? hu ihu ? ihv
-    | ? c ?? hξ ih
-    | ?
-    | ?
-    | ?
+      ????? ht iht hu ihu
+    | ???????? iht ihξ
+    | ??????? hσ ih ?
+    | ????? ihA ? ihB
+    | ????? ihA ? iht
+    |  u ??? hu ihu ? ihv
+    |  c ?? hξ ih
+    |
+    |
+    |
     ] using pred_ind_alt.
     - destruct iht as [tr [ht1 ht2]], ihu as [ur [hu1 hu2]].
       eexists. split.
@@ -976,14 +947,12 @@ Section Red.
       eexists. split.
       + econstructor. 2-3: eassumption.
         apply no_match_Pi.
-      + econstructor. 1: eauto.
-        eapply pred_ctx_irr. eauto.
+      + econstructor. all: eauto.
     - destruct ihA as [Ar [hA1 hA2]], iht as [tr [ht1 ht2]].
       eexists. split.
       + econstructor. 2-3: eassumption.
         apply no_match_lam.
-      + econstructor. 1: eauto.
-        eapply pred_ctx_irr. eauto.
+      + econstructor. all: eauto.
     - destruct ihu as [ur [hu1 hu2]], ihv as [vr [hv1 hv2]].
       destruct (is_lam u) eqn: eu.
       + eapply is_lam_inv in eu as (A & b & ->).
@@ -1044,16 +1013,15 @@ Section Red.
       + eexists. split.
         * econstructor. assumption.
         * constructor.
-    Unshelve. constructor.
   Qed.
 
-  Lemma pred_max_functional Γ t u v :
-    Γ ⊢ t ⇒ᵨ u →
-    Γ ⊢ t ⇒ᵨ v →
+  Lemma pred_max_functional t u v :
+    t ⇒ᵨ u →
+    t ⇒ᵨ v →
     u = v.
   Proof.
     intros hu hv.
-    induction hu as [ | | | | | | | | | ??????? h ? ihσ ? ] in v, hv |- *
+    induction hu as [ | | | | | | | | | ?????? h ? ihσ ? ] in v, hv |- *
     using pred_max_ind_alt.
     - inversion hv.
       3:{ exfalso. eapply no_match_no_match_pat. all: eassumption. }
@@ -1110,8 +1078,8 @@ Section Red.
       cbn. intros ?? (? & h1 & h2). eauto.
   Qed.
 
-  Lemma pred_diamond Γ :
-    diamond (pred Γ).
+  Lemma pred_diamond :
+    diamond pred.
   Proof.
     intros t u v hu hv.
     eapply triangle in hu as [w [hw ?]], hv as [? []].
@@ -1119,15 +1087,15 @@ Section Red.
     subst. exists w. intuition eauto.
   Qed.
 
-  Lemma pred_confluence Γ :
-    confluent (pred Γ).
+  Lemma pred_confluence :
+    confluent pred.
   Proof.
     apply diamond_confluent.
     apply pred_diamond.
   Qed.
 
-  #[export] Instance Reflexive_pred Γ :
-    Reflexive (pred Γ).
+  #[export] Instance Reflexive_pred :
+    Reflexive pred.
   Proof.
     intros t.
     apply pred_refl.
@@ -1135,8 +1103,8 @@ Section Red.
 
 End Red.
 
-Notation "Σ ;; Ξ | Γ ⊢ u ⇒ v" :=
-  (pred Σ Ξ Γ u v)
+Notation "Σ ;; Ξ ⊢ u ⇒ v" :=
+  (pred Σ Ξ u v)
   (at level 80, u, v at next level).
 
 (** ** Sandwishing reduction *)
@@ -1180,9 +1148,9 @@ Proof.
   - cbn. apply (ih (S >> σ)). lia.
 Qed.
 
-Lemma red1_pred Σ Ξ Γ u v :
-  Σ ;; pctx_ictx Ξ | Γ ⊢ u ↦ v →
-  Σ ;; Ξ | Γ ⊢ u ⇒ v.
+Lemma red1_pred Σ Ξ u v :
+  Σ ;; pctx_ictx Ξ ⊢ u ↦ v →
+  Σ ;; Ξ ⊢ u ⇒ v.
 Proof.
   intros h.
   induction h using red1_ind_alt.
@@ -1207,9 +1175,9 @@ Proof.
     intros ??. apply some_rel_option_rel.
 Qed.
 
-Lemma red_const Σ Ξ Γ c ξ ξ' :
-  Forall2 (option_rel (red Σ Ξ Γ)) ξ ξ' →
-  Σ ;; Ξ | Γ ⊢ const c ξ ↦* const c ξ'.
+Lemma red_const Σ Ξ c ξ ξ' :
+  Forall2 (option_rel (red Σ Ξ)) ξ ξ' →
+  Σ ;; Ξ ⊢ const c ξ ↦* const c ξ'.
 Proof.
   intros hξ.
   eapply Forall2_impl in hξ. 2: eapply option_rel_rt_some_rel.
@@ -1225,9 +1193,9 @@ Proof.
   constructor. assumption.
 Qed.
 
-Lemma pred_red Σ Ξ Γ u v :
-  Σ ;; Ξ | Γ ⊢ u ⇒ v →
-  Σ ;; pctx_ictx Ξ | Γ ⊢ u ↦* v.
+Lemma pred_red Σ Ξ u v :
+  Σ ;; Ξ ⊢ u ⇒ v →
+  Σ ;; pctx_ictx Ξ ⊢ u ↦* v.
 Proof.
   intros h.
   induction h using pred_ind_alt.

--- a/theories/Reduction.v
+++ b/theories/Reduction.v
@@ -25,21 +25,21 @@ Require Import Equations.Prop.DepElim.
 
 Section Red.
 
-  Reserved Notation "Γ ⊢ u ↦ v"
-    (at level 80, u, v at next level).
+  Reserved Notation "u ↦ v"
+    (at level 80).
 
   Context (Σ : gctx) (Ξ : ictx).
 
-  Inductive red1 (Γ : ctx) : term → term → Prop :=
+  Inductive red1 : term → term → Prop :=
 
   (** Computation rules *)
 
-  | red_beta A t u : Γ ⊢ app (lam A t) u ↦ t <[ u .. ]
+  | red_beta A t u : app (lam A t) u ↦ t <[ u .. ]
 
   | red_unfold c ξ Ξ' A t :
       Σ c = Some (Def Ξ' A t) →
       closed t = true →
-      Γ ⊢ const c ξ ↦ inst ξ t
+      const c ξ ↦ inst ξ t
 
   | red_rule n rl σ :
       ictx_get Ξ n = Some (Comp rl) →
@@ -49,49 +49,49 @@ Section Red.
       let rhs := rl.(cr_rep) in
       scoped k lhs = true →
       scoped k rhs = true →
-      Γ ⊢ lhs <[ σ ] ↦ rhs <[ σ ]
+      lhs <[ σ ] ↦ rhs <[ σ ]
 
   (** Congruence rules *)
 
   | red_Pi_dom A B A' :
-      Γ ⊢ A ↦ A' →
-      Γ ⊢ Pi A B ↦ Pi A' B
+      A ↦ A' →
+      Pi A B ↦ Pi A' B
 
   | red_Pi_cod A B B' :
-      Γ ,, A ⊢ B ↦ B' →
-      Γ ⊢ Pi A B ↦ Pi A B'
+      B ↦ B' →
+      Pi A B ↦ Pi A B'
 
   | red_lam_dom A t A' :
-      Γ ⊢ A ↦ A' →
-      Γ ⊢ lam A t ↦ lam A' t
+      A ↦ A' →
+      lam A t ↦ lam A' t
 
   | red_lam_body A t t' :
-      Γ ,, A ⊢ t ↦ t' →
-      Γ ⊢ lam A t ↦ lam A t'
+      t ↦ t' →
+      lam A t ↦ lam A t'
 
   | red_app_fun u v u' :
-      Γ ⊢ u ↦ u' →
-      Γ ⊢ app u v ↦ app u' v
+      u ↦ u' →
+      app u v ↦ app u' v
 
   | red_app_arg u v v' :
-      Γ ⊢ v ↦ v' →
-      Γ ⊢ app u v ↦ app u v'
+      v ↦ v' →
+      app u v ↦ app u v'
 
   | red_const c ξ ξ' :
-      OnOne2 (some_rel (λ u v, Γ ⊢ u ↦ v)) ξ ξ' →
-      Γ ⊢ const c ξ ↦ const c ξ'
+      OnOne2 (some_rel (λ u v, u ↦ v)) ξ ξ' →
+      const c ξ ↦ const c ξ'
 
-  where "Γ ⊢ u ↦ v" := (red1 Γ u v).
+  where "u ↦ v" := (red1 u v).
 
   Lemma red1_ind_alt :
-    ∀ (P : ctx → term → term → Prop),
-      (∀ Γ A t u, P Γ (app (lam A t) u) (t <[ u..])) →
-      (∀ Γ c ξ Ξ' A t,
+    ∀ (P : term → term → Prop),
+      (∀ A t u, P (app (lam A t) u) (t <[ u..])) →
+      (∀ c ξ Ξ' A t,
         Σ c = Some (Def Ξ' A t) →
         closed t = true →
-        P Γ (const c ξ) (inst ξ t)
+        P (const c ξ) (inst ξ t)
       ) →
-      (∀ Γ n rl σ,
+      (∀ n rl σ,
         ictx_get Ξ n = Some (Comp rl) →
         let Θ := rl.(cr_env) in
         let k := length Θ in
@@ -99,28 +99,28 @@ Section Red.
         let rhs := rl.(cr_rep) in
         scoped k lhs = true →
         scoped k rhs = true →
-        P Γ (lhs <[ σ]) (rhs <[ σ])
+        P (lhs <[ σ]) (rhs <[ σ])
       ) →
-      (∀ Γ A B A',
-        Γ ⊢ A ↦ A' →
-        P Γ A A' →
-        P Γ (Pi A B) (Pi A' B)
+      (∀ A B A',
+        A ↦ A' →
+        P A A' →
+        P (Pi A B) (Pi A' B)
       ) →
-      (∀ Γ A B B', Γ,, A ⊢ B ↦ B' → P (Γ,, A) B B' → P Γ (Pi A B) (Pi A B')) →
-      (∀ Γ A t A', Γ ⊢ A ↦ A' → P Γ A A' → P Γ (lam A t) (lam A' t)) →
-      (∀ Γ A t t', Γ,, A ⊢ t ↦ t' → P (Γ,, A) t t' → P Γ (lam A t) (lam A t')) →
-      (∀ Γ u v u', Γ ⊢ u ↦ u' → P Γ u u' → P Γ (app u v) (app u' v)) →
-      (∀ Γ u v v', Γ ⊢ v ↦ v' → P Γ v v' → P Γ (app u v) (app u v')) →
-      (∀ Γ c ξ ξ',
-        OnOne2 (some_rel (λ u v : term, Γ ⊢ u ↦ v)) ξ ξ' →
-        OnOne2 (some_rel (P Γ)) ξ ξ' →
-        P Γ (const c ξ) (const c ξ')
+      (∀ A B B', B ↦ B' → P B B' → P (Pi A B) (Pi A B')) →
+      (∀ A t A', A ↦ A' → P A A' → P (lam A t) (lam A' t)) →
+      (∀ A t t', t ↦ t' → P t t' → P (lam A t) (lam A t')) →
+      (∀ u v u', u ↦ u' → P u u' → P (app u v) (app u' v)) →
+      (∀ u v v', v ↦ v' → P v v' → P (app u v) (app u v')) →
+      (∀ c ξ ξ',
+        OnOne2 (some_rel (λ u v : term, u ↦ v)) ξ ξ' →
+        OnOne2 (some_rel P) ξ ξ' →
+        P (const c ξ) (const c ξ')
       ) →
-      ∀ Γ u v, Γ ⊢ u ↦ v → P Γ u v.
+      ∀ u v, u ↦ v → P u v.
   Proof.
     intros P hbeta hunf hrl hpid hpic hlamd hlamb happf happa hconst.
-    fix aux 4. move aux at top.
-    intros Γ u v h. destruct h.
+    fix aux 3. move aux at top.
+    intros u v h. destruct h.
     10:{
       eapply hconst. 1: assumption.
       revert ξ ξ' H. fix aux1 3.
@@ -134,57 +134,57 @@ Section Red.
 
 End Red.
 
-Notation "Σ ;; Ξ | Γ ⊢ u ↦ v" :=
-  (red1 Σ Ξ Γ u v)
+Notation "Σ ;; Ξ ⊢ u ↦ v" :=
+  (red1 Σ Ξ u v)
   (at level 80, u, v at next level).
 
 (** Reflexive transitive closure *)
 
-Definition red Σ Ξ Γ := clos_refl_trans (λ u v, Σ ;; Ξ | Γ ⊢ u ↦ v).
+Definition red Σ Ξ := clos_refl_trans (λ u v, Σ ;; Ξ ⊢ u ↦ v).
 
-Notation "Σ ;; Ξ | Γ ⊢ u ↦* v" :=
-  (red Σ Ξ Γ u v)
+Notation "Σ ;; Ξ ⊢ u ↦* v" :=
+  (red Σ Ξ u v)
   (at level 80, u, v at next level).
 
 (** Equivalence *)
 
-Definition equiv Σ Ξ Γ := clos_refl_sym_trans _ (λ u v, Σ ;; Ξ | Γ ⊢ u ↦ v).
+Definition equiv Σ Ξ := clos_refl_sym_trans _ (λ u v, Σ ;; Ξ ⊢ u ↦ v).
 
-Notation "Σ ;; Ξ | Γ ⊢ u ↮ v" :=
-  (equiv Σ Ξ Γ u v)
+Notation "Σ ;; Ξ ⊢ u ↮ v" :=
+  (equiv Σ Ξ u v)
   (at level 80, u, v at next level).
 
-#[export] Instance equiv_refl Σ Ξ Γ : Reflexive (equiv Σ Ξ Γ).
+#[export] Instance equiv_refl Σ Ξ : Reflexive (equiv Σ Ξ).
 Proof.
   intros u.
   eapply rst_refl.
 Qed.
 
-#[export] Instance equiv_sym Σ Ξ Γ : Symmetric (equiv Σ Ξ Γ).
+#[export] Instance equiv_sym Σ Ξ : Symmetric (equiv Σ Ξ).
 Proof.
   intros u v h.
   eapply rst_sym. eassumption.
 Qed.
 
-#[export] Instance equiv_trans Σ Ξ Γ : Transitive (equiv Σ Ξ Γ).
+#[export] Instance equiv_trans Σ Ξ : Transitive (equiv Σ Ξ).
 Proof.
   intros u v w h1 h2.
   eapply rst_trans. all: eassumption.
 Qed.
 
-Lemma red_ind Σ Ξ Γ Δ f x y :
-  (∀ x y, Σ ;; Ξ | Δ ⊢ x ↦ y → Σ ;; Ξ | Γ ⊢ f x ↦* f y) →
-  Σ ;; Ξ | Δ ⊢ x ↦* y →
-  Σ ;; Ξ | Γ ⊢ f x ↦* f y.
+Lemma red_ind Σ Ξ f x y :
+  (∀ x y, Σ ;; Ξ ⊢ x ↦ y → Σ ;; Ξ ⊢ f x ↦* f y) →
+  Σ ;; Ξ ⊢ x ↦* y →
+  Σ ;; Ξ ⊢ f x ↦* f y.
 Proof.
   intros hred h.
   eapply rt_step_ind. all: eauto.
 Qed.
 
-Lemma equiv_red_ind Σ Ξ Γ Δ f x y :
-  (∀ x y, Σ ;; Ξ | Δ ⊢ x ↦ y → Σ ;; Ξ | Γ ⊢ f x ↮ f y) →
-  Σ ;; Ξ | Δ ⊢ x ↮ y →
-  Σ ;; Ξ | Γ ⊢ f x ↮ f y.
+Lemma equiv_red_ind Σ Ξ f x y :
+  (∀ x y, Σ ;; Ξ ⊢ x ↦ y → Σ ;; Ξ ⊢ f x ↮ f y) →
+  Σ ;; Ξ ⊢ x ↮ y →
+  Σ ;; Ξ ⊢ f x ↮ f y.
 Proof.
   intros hred h.
   eapply rst_step_ind. all: eauto.
@@ -193,23 +193,23 @@ Qed.
 (** Notion of confluence *)
 
 Definition red_confluent Σ Ξ :=
-  ∀ Γ, confluent (red1 Σ Ξ Γ).
+  confluent (red1 Σ Ξ).
 
 (** Joinability *)
 
-Definition red_joinable Σ Ξ Γ :=
-  joinable (red Σ Ξ Γ).
+Definition red_joinable Σ Ξ :=
+  joinable (red Σ Ξ).
 
-Notation "Σ ;; Ξ | Γ ⊢ u ⋈ v" :=
-  (red_joinable Σ Ξ Γ u v)
+Notation "Σ ;; Ξ ⊢ u ⋈ v" :=
+  (red_joinable Σ Ξ u v)
   (at level 80, u, v at next level).
 
 (** Assuming confluence, equivalence is the same as joinability *)
 
-Lemma equiv_join Σ Ξ Γ u v :
+Lemma equiv_join Σ Ξ u v :
   red_confluent Σ Ξ →
-  Σ ;; Ξ | Γ ⊢ u ↮ v →
-  Σ ;; Ξ | Γ ⊢ u ⋈ v.
+  Σ ;; Ξ ⊢ u ↮ v →
+  Σ ;; Ξ ⊢ u ⋈ v.
 Proof.
   intros hc h.
   induction h as [u v hr | u | u v h ih | u v w h1 ih1 h2 ih2 ].
@@ -228,10 +228,10 @@ Qed.
 
 (** Conversion is included in the congruence closure of reduction *)
 
-Lemma equiv_Pi Σ Ξ Γ A A' B B' :
-  Σ ;; Ξ | Γ ⊢ A ↮ A' →
-  Σ ;; Ξ | Γ ,, A ⊢ B ↮ B' →
-  Σ ;; Ξ | Γ ⊢ Pi A B ↮ Pi A' B'.
+Lemma equiv_Pi Σ Ξ A A' B B' :
+  Σ ;; Ξ ⊢ A ↮ A' →
+  Σ ;; Ξ ⊢ B ↮ B' →
+  Σ ;; Ξ ⊢ Pi A B ↮ Pi A' B'.
 Proof.
   intros hA hB.
   transitivity (Pi A B').
@@ -241,10 +241,10 @@ Proof.
     intros. apply rst_step. econstructor. assumption.
 Qed.
 
-Lemma equiv_lam Σ Ξ Γ A A' t t' :
-  Σ ;; Ξ | Γ ⊢ A ↮ A' →
-  Σ ;; Ξ | Γ ,, A ⊢ t ↮ t' →
-  Σ ;; Ξ | Γ ⊢ lam A t ↮ lam A' t'.
+Lemma equiv_lam Σ Ξ A A' t t' :
+  Σ ;; Ξ ⊢ A ↮ A' →
+  Σ ;; Ξ ⊢ t ↮ t' →
+  Σ ;; Ξ ⊢ lam A t ↮ lam A' t'.
 Proof.
   intros hA ht.
   transitivity (lam A t').
@@ -254,10 +254,10 @@ Proof.
     intros. apply rst_step. econstructor. assumption.
 Qed.
 
-Lemma equiv_app Σ Ξ Γ u u' v v' :
-  Σ ;; Ξ | Γ ⊢ u ↮ u' →
-  Σ ;; Ξ | Γ ⊢ v ↮ v' →
-  Σ ;; Ξ | Γ ⊢ app u v ↮ app u' v'.
+Lemma equiv_app Σ Ξ u u' v v' :
+  Σ ;; Ξ ⊢ u ↮ u' →
+  Σ ;; Ξ ⊢ v ↮ v' →
+  Σ ;; Ξ ⊢ app u v ↮ app u' v'.
 Proof.
   intros hu hv.
   transitivity (app u v').
@@ -267,9 +267,9 @@ Proof.
     intros. apply rst_step. econstructor. assumption.
 Qed.
 
-Lemma equiv_const Σ Ξ Γ c ξ ξ' :
-  Forall2 (option_rel (λ u v, Σ ;; Ξ | Γ ⊢ u ↮ v)) ξ ξ' →
-  Σ ;; Ξ | Γ ⊢ const c ξ ↮ const c ξ'.
+Lemma equiv_const Σ Ξ c ξ ξ' :
+  Forall2 (option_rel (λ u v, Σ ;; Ξ ⊢ u ↮ v)) ξ ξ' →
+  Σ ;; Ξ ⊢ const c ξ ↮ const c ξ'.
 Proof.
   intros hξ.
   eapply Forall2_impl in hξ. 2: eapply option_rel_rst_some_rel.
@@ -285,9 +285,9 @@ Proof.
   constructor. assumption.
 Qed.
 
-Lemma conv_equiv Σ Ξ Γ u v :
-  Σ ;; Ξ | Γ ⊢ u ≡ v →
-  Σ ;; Ξ | Γ ⊢ u ↮ v.
+Lemma conv_equiv Σ Ξ u v :
+  Σ ;; Ξ ⊢ u ≡ v →
+  Σ ;; Ξ ⊢ u ↮ v.
 Proof.
   intros h.
   induction h using conversion_ind.
@@ -300,8 +300,8 @@ Qed.
 
 (** One-step reduction embeds in conversion *)
 
-#[export] Instance Reflexive_conversion Σ Ξ Γ :
-  Reflexive (conversion Σ Ξ Γ).
+#[export] Instance Reflexive_conversion Σ Ξ :
+  Reflexive (conversion Σ Ξ).
 Proof.
   intros u. ttconv.
 Qed.
@@ -348,25 +348,25 @@ Section const_eqs.
 
   Context (Σ : gctx) (Ξ : ictx).
 
-  Fixpoint const_eqs (Γ : ctx) t {struct t} :=
+  Fixpoint const_eqs t {struct t} :=
     match t with
     | var x => True
     | Sort s => True
-    | Pi A B => const_eqs Γ A ∧ const_eqs (Γ ,, A) B
-    | lam A b => const_eqs Γ A ∧ const_eqs (Γ ,, A) b
-    | app u v => const_eqs Γ u ∧ const_eqs Γ v
+    | Pi A B => const_eqs A ∧ const_eqs B
+    | lam A b => const_eqs A ∧ const_eqs b
+    | app u v => const_eqs u ∧ const_eqs v
     | const c ξ =>
-        rForall (onSome (const_eqs Γ)) ξ ∧
-        (∃ Ξ' A t, Σ c = Some (Def Ξ' A t) ∧ inst_equations Σ Ξ Γ ξ Ξ')
+        rForall (onSome const_eqs) ξ ∧
+        (∃ Ξ' A t, Σ c = Some (Def Ξ' A t) ∧ inst_equations Σ Ξ ξ Ξ')
     | assm x => True
     end.
 
 End const_eqs.
 
-Lemma red1_conv Σ Ξ Γ u v :
-  const_eqs Σ Ξ Γ u →
-  Σ ;; Ξ | Γ ⊢ u ↦ v →
-  Σ ;; Ξ | Γ ⊢ u ≡ v.
+Lemma red1_conv Σ Ξ u v :
+  const_eqs Σ Ξ u →
+  Σ ;; Ξ ⊢ u ↦ v →
+  Σ ;; Ξ ⊢ u ≡ v.
 Proof.
   intros hu h.
   induction h using red1_ind_alt.
@@ -385,10 +385,10 @@ Proof.
     eauto.
 Qed.
 
-Lemma red1_const_eqs Σ Ξ Γ u v :
-  const_eqs Σ Ξ Γ u →
-  Σ ;; Ξ | Γ ⊢ u ↦ v →
-  const_eqs Σ Ξ Γ v.
+Lemma red1_const_eqs Σ Ξ u v :
+  const_eqs Σ Ξ u →
+  Σ ;; Ξ ⊢ u ↦ v →
+  const_eqs Σ Ξ v.
 Proof.
   intros hu h.
   induction h using red1_ind_alt.
@@ -399,16 +399,13 @@ Proof.
       somehow to add this to the Σ. And then we deduce it later from SR.
     *)
     admit.
-  - cbn in *. (* context again, irrelevant though *)
-    intuition eauto. admit.
-  - admit.
   - cbn in *. admit.
 Admitted.
 
-Lemma red_const_eqs Σ Ξ Γ u v :
-  const_eqs Σ Ξ Γ u →
-  Σ ;; Ξ | Γ ⊢ u ↦* v →
-  const_eqs Σ Ξ Γ v.
+Lemma red_const_eqs Σ Ξ u v :
+  const_eqs Σ Ξ u →
+  Σ ;; Ξ ⊢ u ↦* v →
+  const_eqs Σ Ξ v.
 Proof.
   intros hu h.
   induction h.
@@ -417,10 +414,10 @@ Proof.
   - eauto.
 Qed.
 
-Lemma red_conv Σ Ξ Γ u v :
-  const_eqs Σ Ξ Γ u →
-  Σ ;; Ξ | Γ ⊢ u ↦* v →
-  Σ ;; Ξ | Γ ⊢ u ≡ v.
+Lemma red_conv Σ Ξ u v :
+  const_eqs Σ Ξ u →
+  Σ ;; Ξ ⊢ u ↦* v →
+  Σ ;; Ξ ⊢ u ≡ v.
 Proof.
   intros hu h.
   induction h.
@@ -429,11 +426,11 @@ Proof.
   - eapply conv_trans. all: eauto using red_const_eqs.
 Qed.
 
-Lemma join_conv Σ Ξ Γ u v :
-  const_eqs Σ Ξ Γ u →
-  const_eqs Σ Ξ Γ v →
-  Σ ;; Ξ | Γ ⊢ u ⋈ v →
-  Σ ;; Ξ | Γ ⊢ u ≡ v.
+Lemma join_conv Σ Ξ u v :
+  const_eqs Σ Ξ u →
+  const_eqs Σ Ξ v →
+  Σ ;; Ξ ⊢ u ⋈ v →
+  Σ ;; Ξ ⊢ u ≡ v.
 Proof.
   intros hcu hcv (w & hu & hv).
   eapply conv_trans.
@@ -443,7 +440,7 @@ Qed.
 
 (** * Context reduction *)
 
-Reserved Notation "Σ ;; Ξ | Γ ↦* Δ" (at level 80).
+(* Reserved Notation "Σ ;; Ξ | Γ ↦* Δ" (at level 80).
 
 Inductive red_ctx (Σ : gctx) (Ξ : ictx) : ctx → ctx → Prop :=
 | red_nil : Σ ;; Ξ | ∙ ↦* ∙
@@ -452,7 +449,7 @@ Inductive red_ctx (Σ : gctx) (Ξ : ictx) : ctx → ctx → Prop :=
     Σ ;; Ξ | Γ ⊢ A ↦* B →
     Σ ;; Ξ | Γ ,, A ↦* Δ ,, B
 
-where "Σ ;; Ξ | Γ ↦* Δ" := (red_ctx Σ Ξ Γ Δ).
+where "Σ ;; Ξ | Γ ↦* Δ" := (red_ctx Σ Ξ Γ Δ). *)
 
 (* Lemma red_ctx_red1 Σ Ξ Γ Δ u v :
   Σ ;; Ξ | Δ ↦* Γ →
@@ -498,8 +495,8 @@ Definition no_pi_lhs (Σ : gctx) Ξ :=
     let lhs := rl.(cr_pat) in
     Pi A B ≠ lhs <[ σ ].
 
-#[export] Instance Reflexive_red Σ Ξ Γ :
-  Reflexive (red Σ Ξ Γ).
+#[export] Instance Reflexive_red Σ Ξ :
+  Reflexive (red Σ Ξ).
 Proof.
   intros u. apply rt_refl.
 Qed.
@@ -507,8 +504,8 @@ Qed.
 Derive Signature for red1.
 Derive Signature for clos_refl_trans.
 
-#[export] Instance Transitive_red Σ Ξ Γ :
-  Transitive (red Σ Ξ Γ).
+#[export] Instance Transitive_red Σ Ξ :
+  Transitive (red Σ Ξ).
 Proof.
   intros u v w. eapply rt_trans.
 Qed.
@@ -517,12 +514,12 @@ Section Injectivity.
 
   Context Σ Ξ (hnopi : no_pi_lhs Σ Ξ).
 
-  Lemma red1_pi_inv Γ A B T :
-    Σ ;; Ξ | Γ ⊢ Pi A B ↦ T →
+  Lemma red1_pi_inv A B T :
+    Σ ;; Ξ ⊢ Pi A B ↦ T →
     ∃ A' B',
       T = Pi A' B' ∧
-      Σ ;; Ξ | Γ ⊢ A ↦* A' ∧
-      Σ ;; Ξ | Γ ,, A ⊢ B ↦* B'.
+      Σ ;; Ξ ⊢ A ↦* A' ∧
+      Σ ;; Ξ ⊢ B ↦* B'.
   Proof.
     intros h.
     depelim h.
@@ -535,12 +532,12 @@ Section Injectivity.
       + apply rt_step. assumption.
   Qed.
 
-  Lemma red_pi_inv Γ A B T :
-    Σ ;; Ξ | Γ ⊢ Pi A B ↦* T →
+  Lemma red_pi_inv A B T :
+    Σ ;; Ξ ⊢ Pi A B ↦* T →
     ∃ A' B',
       T = Pi A' B' ∧
-      Σ ;; Ξ | Γ ⊢ A ↦* A' ∧
-      Σ ;; Ξ | Γ ,, A ⊢ B ↦* B'.
+      Σ ;; Ξ ⊢ A ↦* A' ∧
+      Σ ;; Ξ ⊢ B ↦* B'.
   Proof.
     intros h.
     dependent induction h.
@@ -555,10 +552,10 @@ Section Injectivity.
         (* Would need context conversion *)
   Admitted.
 
-  Lemma join_pi_inv Γ A B A' B' :
-    Σ ;; Ξ | Γ ⊢ Pi A B ⋈ Pi A' B' →
-    Σ ;; Ξ | Γ ⊢ A ⋈ A' ∧
-    Σ ;; Ξ | Γ ,, A ⊢ B ⋈ B'.
+  Lemma join_pi_inv A B A' B' :
+    Σ ;; Ξ ⊢ Pi A B ⋈ Pi A' B' →
+    Σ ;; Ξ ⊢ A ⋈ A' ∧
+    Σ ;; Ξ ⊢ B ⋈ B'.
   Proof.
     intros (T & h & h').
     eapply red_pi_inv in h as (A1 & B1 & -> & hA1 & hB1), h' as (?&?&e&hA2&hB2).
@@ -566,8 +563,6 @@ Section Injectivity.
     split.
     - exists A1. intuition assumption.
     - exists B1. intuition auto.
-      (* Context conversion too *)
-      admit.
-  Admitted.
+  Qed.
 
 End Injectivity.


### PR DESCRIPTION
Things are simpler without, although it feels like we're losing information.
Contexts would be needed to support let-bindings, but if we ever need them, we should probably encode them instead (use the current theory as a model).